### PR TITLE
chore: use main instead of master for craft related files

### DIFF
--- a/.craft.ini
+++ b/.craft.ini
@@ -1,5 +1,4 @@
 [General]
-Branch = master
 ShallowClone = False
 
 # Variables defined here override the default value

--- a/.craft.shelf
+++ b/.craft.shelf
@@ -1,3 +1,3 @@
 [General]
 version = 2
-blueprintrepositories = https://invent.kde.org/packaging/craft-blueprints-kde.git|master|;https://github.com/opencloud-eu/craft-blueprints-opencloud.git|master|
+blueprintrepositories = https://invent.kde.org/packaging/craft-blueprints-kde.git|master|;https://github.com/opencloud-eu/craft-blueprints-opencloud.git|main|


### PR DESCRIPTION
`craft` related files were referencing `master` as the main branch of this repo. fixed that.