### PR TITLE
Move folder context menu to qml

### DIFF
--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -99,7 +99,6 @@ protected Q_SLOTS:
     void slotFolderWizardAccepted();
     void slotDeleteAccount();
     void slotToggleSignInState();
-    void slotCustomContextMenuRequested(Folder *folder);
 
 private:
     void showSelectiveSyncDialog(Folder *folder);

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -138,6 +138,12 @@ class OPENCLOUD_GUI_EXPORT Folder : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(GraphApi::Space *space READ space NOTIFY spaceChanged)
+    Q_PROPERTY(QString path READ path CONSTANT)
+    Q_PROPERTY(QUrl webDavUrl READ webDavUrl CONSTANT)
+    Q_PROPERTY(bool isReady READ isReady NOTIFY isReadyChanged)
+    Q_PROPERTY(bool isSyncPaused READ isSyncPaused NOTIFY syncPausedChanged)
+    Q_PROPERTY(bool isSyncRunning READ isSyncRunning NOTIFY isSyncRunningChanged)
+    Q_PROPERTY(bool isDeployed READ isDeployed CONSTANT)
     QML_ELEMENT
     QML_UNCREATABLE("Folders can only be created by the FolderManager")
 
@@ -192,7 +198,7 @@ public:
      */
     void setSyncPaused(bool);
 
-    bool syncPaused() const;
+    bool isSyncPaused() const;
 
     /**
      * Returns true when the folder may sync.
@@ -327,6 +333,8 @@ Q_SIGNALS:
     void syncPausedChanged(Folder *, bool paused);
     void canSyncChanged();
     void spaceChanged();
+    void isReadyChanged();
+    void isSyncRunningChanged();
 
 
     /**
@@ -336,6 +344,8 @@ Q_SIGNALS:
     void watchedFileChangedExternally(const QString &path);
 
 public Q_SLOTS:
+    void openInWebBrowser();
+
     /**
        * terminate the current sync run
        */
@@ -420,6 +430,8 @@ private:
     bool checkLocalPath();
 
     SyncOptions loadSyncOptions();
+
+    void setIsReady(bool b);
 
     /**
      * Sets up this folder's folderWatcher if possible.

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -62,7 +62,7 @@ void TrayOverallStatusResult::addResult(Folder *f)
         lastSyncDone = time;
     }
 
-    auto status = f->syncPaused() || NetworkInformation::instance()->isBehindCaptivePortal() || NetworkInformation::instance()->isMetered()
+    auto status = f->isSyncPaused() || NetworkInformation::instance()->isBehindCaptivePortal() || NetworkInformation::instance()->isMetered()
         ? SyncResult::Paused
         : f->syncResult().status();
     if (status == SyncResult::Undefined) {
@@ -466,7 +466,7 @@ Folder *FolderMan::addFolderInternal(
 
     qCInfo(lcFolderMan) << "Adding folder to Folder Map " << folder << folder->path();
     _folders.push_back(folder);
-    if (folder->syncPaused()) {
+    if (folder->isSyncPaused()) {
         _disabledFolders.insert(folder);
     }
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -45,7 +45,7 @@ namespace {
         auto status = f->syncResult();
         if (!f->accountState()->isConnected()) {
             status.setStatus(SyncResult::Status::Offline);
-        } else if (f->syncPaused() || NetworkInformation::instance()->isBehindCaptivePortal() || NetworkInformation::instance()->isMetered()) {
+        } else if (f->isSyncPaused() || NetworkInformation::instance()->isBehindCaptivePortal() || NetworkInformation::instance()->isMetered()) {
             status.setStatus(SyncResult::Status::Paused);
         }
         return QStringLiteral("states/%1").arg(Theme::instance()->syncStateIconName(status));

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -243,7 +243,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
     const auto &map = FolderMan::instance()->folders();
     for (auto *f : map) {
-        if (!f->syncPaused()) {
+        if (!f->isSyncPaused()) {
             allPaused = false;
         }
     }
@@ -304,9 +304,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 #else
     QStringList allStatusStrings;
     for (auto *folder : map) {
-        QString folderMessage = FolderMan::trayTooltipStatusString(
-            folder->syncResult(),
-            folder->syncPaused());
+        QString folderMessage = FolderMan::trayTooltipStatusString(folder->syncResult(), folder->isSyncPaused());
         allStatusStrings += tr("Folder %1: %2").arg(folder->shortGuiLocalPath(), folderMessage);
     }
     trayMessage = allStatusStrings.join(QLatin1String("\n"));
@@ -354,7 +352,7 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
             continue;
         }
 
-        if (folder->syncPaused()) {
+        if (folder->isSyncPaused()) {
             onePaused = true;
         }
         menu->addAction(tr("Open folder '%1'").arg(folder->shortGuiLocalPath()), this, [this, folder] { slotFolderOpenAction(folder); });
@@ -461,7 +459,7 @@ void ownCloudGui::updateContextMenu()
     }
 
     for (auto *f : FolderMan::instance()->folders()) {
-        if (f->syncPaused()) {
+        if (f->isSyncPaused()) {
             atLeastOnePaused = true;
         }
     }

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -515,11 +515,6 @@ bool Theme::enableMoveToTrash() const
     return true;
 }
 
-bool Theme::syncNewlyDiscoveredSpaces() const
-{
-    return false;
-}
-
 bool Theme::enableCernBranding() const
 {
     return false;

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -72,7 +72,6 @@ class OPENCLOUD_SYNC_EXPORT Theme : public QObject
     Q_OBJECT
     Q_PROPERTY(bool multiAccount READ multiAccount FINAL CONSTANT)
     Q_PROPERTY(QList<QmlUrlButton> urlButtons READ qmlUrlButtons FINAL CONSTANT)
-    Q_PROPERTY(bool syncNewlyDiscoveredSpaces READ syncNewlyDiscoveredSpaces FINAL CONSTANT)
     Q_PROPERTY(QColor avatarColor READ avatarColor NOTIFY themeChanged)
     Q_PROPERTY(QColor avatarColorChecked READ avatarColorChecked NOTIFY themeChanged)
     Q_PROPERTY(QColor brandedBackgoundColor READ wizardHeaderBackgroundColor CONSTANT)
@@ -425,14 +424,6 @@ public:
      * Default: true
      */
     virtual bool enableMoveToTrash() const;
-
-    /**
-     * @brief Automatically add sync connections for newly discovered Spaces.
-     *
-     * Default: false
-     * See #11749
-     */
-    virtual bool syncNewlyDiscoveredSpaces() const;
 
     /**
      * Whether to enable the special code for cernbox


### PR DESCRIPTION
This also removes the vfs menu, an entry which we have to revisit, once we have vfs back.

`syncNewlyDiscoveredSpaces` was also removed, here we need a new concept.