### PR TITLE
Re imagine the terminal

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(cmd
 set_target_properties(cmd PROPERTIES OUTPUT_NAME "${APPLICATION_EXECUTABLE}cmd")
 ecm_mark_nongui_executable(cmd)
 
-target_link_libraries(cmd csync libsync Qt::Core Qt::Network)
+target_link_libraries(cmd csync libsync Qt::Core Qt::Network ZLIB::ZLIB)
 apply_common_target_settings(cmd)
 
 if(APPLE)

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -326,16 +326,18 @@ CmdOptions parseOptions(const QStringList &app_args)
         {{QStringLiteral("t"), QStringLiteral("token")}, QStringLiteral("Authentication token, you can also use $OPENCLOUD_TOKEN"), QStringLiteral("token")});
 
     auto remoteFolder =
-        addOption({{QStringLiteral("remote-folder")}, QStringLiteral("A subdirectory of the space that is synchronized"), QStringLiteral("remote-folder")});
-    auto httpproxyOption = addOption({{QStringLiteral("httpproxy")}, QStringLiteral("Specify a http proxy to use"), QStringLiteral("http://server:port")});
+        addOption({{QStringLiteral("remote-folder")}, QStringLiteral("The subdirectory of the space that is synchronized"), QStringLiteral("remote-folder")});
+    auto httpproxyOption = addOption({{QStringLiteral("http-proxy")}, QStringLiteral("Specify a http proxy to use"), QStringLiteral("http://server:port")});
     auto trustOption = addOption({ { QStringLiteral("trust") }, QStringLiteral("Trust the SSL certification") });
     auto excludeOption = addOption({ { QStringLiteral("exclude") }, QStringLiteral("Path to an exclude list [file]"), QStringLiteral("file") });
-    auto unsyncedfoldersOption = addOption({ { QStringLiteral("unsyncedfolders") }, QStringLiteral("File containing the list of unsynced remote folders (selective sync)"), QStringLiteral("file") });
+    auto unsyncedfoldersOption = addOption(
+        {{QStringLiteral("unsynced-folders")}, QStringLiteral("File containing the list of unsynced remote folders (selective sync)"), QStringLiteral("file")});
 
     auto nonInterActiveOption = addOption({ { QStringLiteral("non-interactive") }, QStringLiteral("Do not block execution with interaction") });
     auto maxRetriesOption = addOption({{QStringLiteral("max-sync-retries")}, QStringLiteral("Retries maximum n times (defaults to 3)"), QStringLiteral("n")});
-    auto uploadLimitOption = addOption({ { QStringLiteral("uplimit") }, QStringLiteral("Limit the upload speed of files to n KB/s"), QStringLiteral("n") });
-    auto downloadLimitption = addOption({ { QStringLiteral("downlimit") }, QStringLiteral("Limit the download speed of files to n KB/s"), QStringLiteral("n") });
+    auto uploadLimitOption = addOption({{QStringLiteral("upload-limit")}, QStringLiteral("Limit the upload speed of files to n KB/s"), QStringLiteral("n")});
+    auto downloadLimitption =
+        addOption({{QStringLiteral("download-limit")}, QStringLiteral("Limit the download speed of files to n KB/s"), QStringLiteral("n")});
     auto syncHiddenFilesOption = addOption({ { QStringLiteral("sync-hidden-files") }, QStringLiteral("Enables synchronization of hidden files") });
 
     const auto testCrashReporter =

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -341,7 +341,11 @@ CmdOptions parseOptions(const QStringList &app_args)
     const auto testCrashReporter =
         addOption({{QStringLiteral("crash")}, QStringLiteral("Crash the client to test the crash reporter")}, QCommandLineOption::HiddenFromHelp);
 
-    auto verbosityOption = addOption({{QStringLiteral("verbose")}, QStringLiteral("Specify the [verbosity], valid values 0, 1, 2. (defaults to 0)."),
+    auto verbosityOption = addOption({{QStringLiteral("verbose")},
+        QStringLiteral("Specify the [verbosity]\n0: no logging (default)\n"
+                       "1: general logging\n"
+                       "2: all previous and http logs\n"
+                       "3: all previous and debug information"),
         QStringLiteral("verbosity"), QStringLiteral("0")});
 
     parser.addHelpOption();
@@ -359,9 +363,12 @@ CmdOptions parseOptions(const QStringList &app_args)
 
 
     const int verbosity = parser.value(verbosityOption).toInt();
-    if (verbosity >= 0 && verbosity <= 2) {
+    if (verbosity >= 0 && verbosity <= 3) {
         logQuietMode = verbosity == 0;
         if (verbosity > 1) {
+            Logger::instance()->addLogRule({QStringLiteral("sync.httplogger=true")});
+        }
+        if (verbosity > 2) {
             Logger::instance()->setLogDebug(true);
         }
     } else {

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -215,6 +215,7 @@ void setupLogging(const CommandLineOptions &options)
 {
     // might be called from second instance
     auto logger = Logger::instance();
+    logger->install();
     // call setLogFlush first, other log settings might already imply flushing
     // so setting it false in the end will have undesired results.
     logger->setLogFlush(options.logFlush);

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -37,6 +37,11 @@ class OPENCLOUD_SYNC_EXPORT Logger : public QObject
 public:
     static QString loggerPattern();
 
+    /**
+     * Install the mesage handler
+     */
+    void install();
+
     bool isLoggingToFile() const;
 
     void attacheToConsole();
@@ -105,6 +110,7 @@ private:
     bool _consoleIsAttached = false;
 
     int _maxLogFiles;
+    bool _loggerInstalled = false;
 };
 
 } // namespace OCC

--- a/src/libsync/platform_mac.h
+++ b/src/libsync/platform_mac.h
@@ -29,6 +29,8 @@ public:
     MacPlatform();
     ~MacPlatform() override;
 
+    void setApplication(QCoreApplication *application) override;
+
     void migrate() override;
 
     void startServices() override;


### PR DESCRIPTION
# The new interface
```
Usage: /Users/h.vonreth/CraftRoot/download/git/opencloud/opencloud-desktop/cmake-build-relwithdebinfo/bin/opencloud.app/Contents/MacOS/opencloudcmd [options] server_url [space_id] [source_dir]
opencloudcmd version 1.0.0-git - command line client tool

Options:
  -u, --user <name>                 Username
  -t, --token <token>               Authentication token, you can also use
                                    $OPENCLOUD_TOKEN
  --remote-folder <remote-folder>   A subdirectory of the space that is
                                    synchronized
  --httpproxy <http://server:port>  Specify a http proxy to use
  --trust                           Trust the SSL certification
  --exclude <file>                  Path to an exclude list [file]
  --unsyncedfolders <file>          File containing the list of unsynced remote
                                    folders (selective sync)
  --non-interactive                 Do not block execution with interaction
  --max-sync-retries <n>            Retries maximum n times (defaults to 3)
  --uplimit <n>                     Limit the upload speed of files to n KB/s
  --downlimit <n>                   Limit the download speed of files to n KB/s
  --sync-hidden-files               Enables synchronization of hidden files
  --verbose <verbosity>             Specify the [verbosity], valid values 0, 1,
                                    2. (defaults to 0).
  -h, --help                        Displays help on commandline options.
  --help-all                        Displays help, including generic Qt
                                    options.
  -v, --version                     Displays version information.

Arguments:
  server_url                        The URL to the OpenCloud installation on
                                    the server. This is usually the root path
  space_id                          The id, name or short id of the space to
                                    synchronize, if no [space_id] is provided or
                                    the [space_id] did not match any space, a
                                    list of spaces is printed.
  source_dir                        The source dir
```

# Querying spaces
```
Listing spaces:
       Short ID |          DisplayName | ID
--------------- | -------------------- | --------------------
 space:aed11295 |             Personal | 280d6759-f99f-40b2-b3e6-be11679c8750$b1f74ec4-dd7e-11ef-a543-03775734d0f7
 space:aa431255 |               Shares | a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
```