### PR TITLE
Hide autostart settings when installed from the Microsoft Store

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -136,16 +136,20 @@ void GeneralSettings::reloadConfig()
 {
     _ui->syncHiddenFilesCheckBox->setChecked(!FolderMan::instance()->ignoreHiddenFiles());
     _ui->moveToTrashCheckBox->setChecked(ConfigFile().moveToTrash());
-    if (Utility::hasSystemLaunchOnStartup(Theme::instance()->appName())) {
-        _ui->autostartCheckBox->setChecked(true);
-        _ui->autostartCheckBox->setDisabled(true);
-        _ui->autostartCheckBox->setToolTip(tr("You cannot disable autostart because system-wide autostart is enabled."));
+    if (Utility::isWindows() && Utility::isInstalledByStore()) {
+        _ui->autostartCheckBox->setVisible(false);
     } else {
-        const bool hasAutoStart = Utility::hasLaunchOnStartup(Theme::instance()->appName());
-        // make sure the binary location is correctly set
-        slotToggleLaunchOnStartup(hasAutoStart);
-        _ui->autostartCheckBox->setChecked(hasAutoStart);
-        connect(_ui->autostartCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleLaunchOnStartup);
+        if (Utility::hasSystemLaunchOnStartup(Theme::instance()->appName())) {
+            _ui->autostartCheckBox->setChecked(true);
+            _ui->autostartCheckBox->setDisabled(true);
+            _ui->autostartCheckBox->setToolTip(tr("You cannot disable autostart because system-wide autostart is enabled."));
+        } else {
+            const bool hasAutoStart = Utility::hasLaunchOnStartup(Theme::instance()->appName());
+            // make sure the binary location is correctly set
+            slotToggleLaunchOnStartup(hasAutoStart);
+            _ui->autostartCheckBox->setChecked(hasAutoStart);
+            connect(_ui->autostartCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleLaunchOnStartup);
+        }
     }
 }
 

--- a/src/gui/guiutility.h
+++ b/src/gui/guiutility.h
@@ -52,6 +52,8 @@ namespace Utility {
 
     QString socketApiSocketPath();
 
+    bool isInstalledByStore();
+
     OPENCLOUD_GUI_EXPORT void markDirectoryAsSyncRoot(const QString &path, const QUuid &accountUuid);
     std::pair<QString, QUuid> getDirectorySyncRootMarkings(const QString &path);
     void unmarkDirectoryAsSyncRoot(const QString &path);

--- a/src/gui/guiutility_mac.mm
+++ b/src/gui/guiutility_mac.mm
@@ -58,4 +58,9 @@ QString Utility::socketApiSocketPath()
     return QStringLiteral("%1%2.socketApi").arg(QStringLiteral(SOCKETAPI_TEAM_IDENTIFIER_PREFIX), Theme::instance()->orgDomainName());
 }
 
+bool Utility::isInstalledByStore()
+{
+    return false;
+}
+
 } // namespace OCC

--- a/src/gui/guiutility_unix.cpp
+++ b/src/gui/guiutility_unix.cpp
@@ -28,4 +28,9 @@ QString Utility::socketApiSocketPath()
     return QStringLiteral("%1/OpenCloud/socket").arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation));
 }
 
+bool Utility::isInstalledByStore()
+{
+    return false;
+}
+
 } // namespace OCC

--- a/src/gui/guiutility_win.cpp
+++ b/src/gui/guiutility_win.cpp
@@ -17,6 +17,11 @@
 
 #include <QCoreApplication>
 
+// windows.h mus be included before appmodel.h
+#include <windows.h>
+
+#include <appmodel.h>
+
 namespace OCC {
 
 void Utility::startShellIntegration()
@@ -26,6 +31,12 @@ void Utility::startShellIntegration()
 QString Utility::socketApiSocketPath()
 {
     return QStringLiteral(R"(\\.\pipe\OpenCloud-%1)").arg(qEnvironmentVariable("USERNAME"));
+}
+
+bool Utility::isInstalledByStore()
+{
+    uint32_t length = 0;
+    return GetCurrentPackageFamilyName(&length, nullptr) != APPMODEL_ERROR_NO_PACKAGE;
 }
 
 } // namespace OCC


### PR DESCRIPTION
When installed through the store, the use must use the system settings

Fixes: #192