### PR TITLE
Fix WebFinger rel ID to match server implementation

### DIFF
--- a/src/libsync/creds/webfinger.cpp
+++ b/src/libsync/creds/webfinger.cpp
@@ -88,5 +88,5 @@ const QUrl &WebFinger::href() const
 
 QString WebFinger::relId()
 {
-    return QStringLiteral("http://webfinger.opencloud.eu/rel/server-instance");
+    return QStringLiteral("http://webfinger.opencloud/rel/server-instance");
 }

--- a/src/libsync/creds/webfinger.cpp
+++ b/src/libsync/creds/webfinger.cpp
@@ -37,7 +37,7 @@ WebFinger::WebFinger(QNetworkAccessManager *nam, QObject *parent)
 
 void WebFinger::start(const QUrl &url, const QString &resourceId)
 {
-    //    GET /.well-known/webfinger?rel=http://webfinger.opencloud.eu/rel/server-instance&resource=acct:test@opencloud.eu HTTP/1.1
+    //    GET /.well-known/webfinger?rel=http://webfinger.opencloud/rel/server-instance&resource=acct:test@opencloud.eu HTTP/1.1
     if (OC_ENSURE(url.scheme() == QLatin1String("https"))) {
         QUrlQuery query;
         query.setQueryItems({ { QStringLiteral("resource"), QString::fromUtf8(QUrl::toPercentEncoding(resourceId)) },

--- a/src/libsync/creds/webfinger.h
+++ b/src/libsync/creds/webfinger.h
@@ -37,6 +37,13 @@ public:
 
     /***
      * ID used to describe our rel attribute
+     * Defined on the server in services/webfinger/pkg/relations/owncloud_instance.go as OpenCloudInstanceRel
+     * The server uses "http://webfinger.opencloud/rel/server-instance" (without .eu)
+     * 
+     * According to RFC 7033 (WebFinger), the "rel" is either a URI or a registered relation type
+     * as specified in RFC 5988 (Web Linking). For custom relation types like this one, 
+     * a URI format is used as described in RFC 7033 section 10.3:
+     * https://datatracker.ietf.org/doc/html/rfc7033#section-10.3
      */
     static QString relId();
 


### PR DESCRIPTION
Fixes #197

The desktop client was expecting `http://webfinger.opencloud.eu/rel/server-instance` but the server uses `http://webfinger.opencloud/rel/server-instance` (without .eu).

This change updates the desktop client to use the correct relation ID. Related to opencloud-eu/opencloud#65.