### PR TITLE
Disable native tooltips on all platforms due to macOS crashes

### DIFF
--- a/src/gui/qml/AccountBar.qml
+++ b/src/gui/qml/AccountBar.qml
@@ -29,7 +29,8 @@ Pane {
     Component.onCompleted: {
         // TODO: Re enable with Qt 6.6.3
         // https://github.com/opencloud-eu/desktop/issues/222
-        if (Qt.platform.os !== "linux") {
+        // Disabled on all platforms due to macOS crashes (issue #224)
+        if (false) { // Disabled on all platforms instead of just Linux
             if ('popupType' in ToolTip.toolTip) {
                 ToolTip.toolTip.popupType = Popup.Native;
             }


### PR DESCRIPTION
## Summary
- Disable native tooltips on all platforms, not just Linux, as they also cause crashes on macOS
- This is a temporary workaround until the underlying Qt issue is fixed (expected in Qt 6.6.3 or later)

## Problem
As documented in issue #224, the OpenCloud Desktop application crashes or becomes unresponsive on macOS when hovering over account buttons. The crash log indicates a hang in the Qt tooltip/popup handling code similar to the issues previously observed on Linux platforms.

The crash occurs in:
```
QQuickPopup::setVisible(bool)
QQuickPopupPrivate::prepareEnterTransition()
QQuickPopupPrivate::adjustPopupItemParentAndWindow()
```

## Solution
This PR extends the existing workaround (which disabled native tooltips only on Linux platforms) to all platforms by changing the condition from:
```qml
if (Qt.platform.os !== "linux") {
    // Use native tooltips
}
```

to:
```qml
if (false) { // Disabled on all platforms instead of just Linux
    // Use native tooltips
}
```

This ensures that native tooltips are disabled on all platforms, preventing crashes on macOS as well as Linux.

## Related Issues
- Fixes #224 (macOS crashes)
- Related to #222 (Qt 6.8.3 or later: Re-enable native tooltips on Linux)
- Related to previous fixes for #212, #207, #195 (Linux crashes)

## Test Plan
- Hover mouse over account buttons or "Add Account" button in the desktop app
- Verify the app does not freeze or crash with spinning beach ball on macOS
- Ensure tooltips still appear but are rendered by QML instead of native tooltips