### PR TITLE
Improve keyboard navigation in setup wizard

### DIFF
--- a/src/gui/newwizard/setupwizardwidget.h
+++ b/src/gui/newwizard/setupwizardwidget.h
@@ -65,6 +65,10 @@ public Q_SLOTS:
      */
     void slotStartTransition();
 
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+
 private Q_SLOTS:
     void slotReplaceContent(QWidget *newWidget);
     void slotHideErrorMessageWidget();


### PR DESCRIPTION
## Summary
- Add keyboard navigation support to the setup wizard
- Enter key now triggers Next/Continue/Done buttons
- Escape key now cancels/closes the wizard dialog
- Installs event filters to capture keyboard events from all child widgets
- Fixes issue #226

## Test plan
1. Start the OpenCloud Desktop app
2. Click on \Add Account\
3. Enter a server URL and press Enter - should continue to next step
4. When the login screen appears, press Enter - should open web browser
5. Complete login and verify Enter key works to finish setup
6. Test that Escape key closes the wizard at any stage
