### PR TITLE
Properly handle `server_error` response from IDP

### DIFF
--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -727,6 +727,8 @@ void AccountBasedOAuth::refreshAuthentication(const QString &refreshToken)
                         } else {
                             qCWarning(lcOauth) << "Error while refreshing the token:" << errorString
                                                << data.value(QStringLiteral("error_description")).toString();
+                            Q_EMIT refreshError(QNetworkReply::NoError, data.value(QStringLiteral("error_description")).toString());
+                            return;
                         }
                     } else if (reply->error() != QNetworkReply::NoError) {
                         qCWarning(lcOauth) << "Error while refreshing the token:" << reply->error() << ":" << reply->errorString()


### PR DESCRIPTION
When the server replied with an error, for example
```
{
  "error": "server_error",
  "error_description": "The authorization server encountered an unexpected condition that prevented it from fulfilling the request."
}
```
We ignored it and retried to authenticate indefinitely.