### PR TITLE
🎉 Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@
 
 @TheOneRing
 
+### 🐛 Bug Fixes
 
+- Properly handle `server_error` response from IDP [[#236](https://github.com/opencloud-eu/desktop/pull/236)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [1.0.1](https://github.com/opencloud-eu/desktop/releases/tag/v1.0.1) - 2025-04-24
+
+### ❤️ Thanks to all contributors! ❤️
+
+@TheOneRing
+
+


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.0.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-1.0` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.0.1](https://github.com/opencloud-eu/desktop/releases/tag/v1.0.1) - 2025-04-24

### 🐛 Bug Fixes

- Properly handle `server_error` response from IDP [[#236](https://github.com/opencloud-eu/desktop/pull/236)]