### PR TITLE
Directly schedule sync once the etag changed

### DIFF
--- a/src/gui/scheduling/etagwatcher.cpp
+++ b/src/gui/scheduling/etagwatcher.cpp
@@ -25,10 +25,6 @@ using namespace std::chrono_literals;
 
 using namespace OCC;
 
-namespace {
-constexpr auto pollTimeoutC = 30s;
-}
-
 Q_LOGGING_CATEGORY(lcEtagWatcher, "gui.scheduler.etagwatcher", QtInfoMsg)
 
 ETagWatcher::ETagWatcher(FolderMan *folderMan, QObject *parent)
@@ -45,41 +41,28 @@ ETagWatcher::ETagWatcher(FolderMan *folderMan, QObject *parent)
                 } else {
                     intersection.emplace(f, QString());
                     connect(&f->syncEngine(), &SyncEngine::rootEtag, this, [f, this](const QString &etag, const QDateTime &time) {
+                        // we don't use update etag here, as we don't want to reschedule the folder
                         _lastEtagJob[f] = etag;
                         f->accountState()->tagLastSuccessfullETagRequest(time);
+                    });
+                    connect(f, &Folder::spaceChanged, this, [f, this] {
+                        const QString etag = Utility::normalizeEtag(f->space()->drive().getRoot().getETag());
+                        // the server must provide a valid etag but there might be bugs
+                        // https://github.com/owncloud/ocis/issues/7160
+                        if (OC_ENSURE_NOT(etag.isEmpty())) {
+                            auto &info = _lastEtagJob[f];
+                            if (f->canSync() && info != etag) {
+                                qCDebug(lcEtagWatcher) << "Scheduling sync of" << f->displayName() << f->path() << "due to an etag change";
+                                info = etag;
+                                _folderMan->scheduler()->enqueueFolder(f);
+                            }
+                        } else {
+                            qCWarning(lcEtagWatcher) << "Invalid empty etag received for" << f->displayName() << f->path();
+                        }
                     });
                 }
             }
         }
         _lastEtagJob = std::move(intersection);
     });
-
-    auto *pollTimer = new QTimer(this);
-    pollTimer->setInterval(pollTimeoutC);
-    connect(pollTimer, &QTimer::timeout, this, [this] {
-        for (auto &info : _lastEtagJob) {
-            // we could also connect to the spaceChanged signal but for legacy reason we poll
-            // ensure we already know about the space (startup)
-            if (auto *space = info.first->space()) {
-                updateEtag(info.first, space->drive().getRoot().getETag());
-            }
-        }
-    });
-    pollTimer->start();
-}
-
-void ETagWatcher::updateEtag(Folder *f, const QString &etag)
-{
-    // the server must provide a valid etag but there might be bugs
-    // https://github.com/owncloud/ocis/issues/7160
-    if (OC_ENSURE_NOT(etag.isEmpty())) {
-        auto &info = _lastEtagJob[f];
-        if (f->canSync() && info != etag) {
-            qCDebug(lcEtagWatcher) << "Scheduling sync of" << f->displayName() << f->path() << "due to an etag change";
-            info = etag;
-            _folderMan->scheduler()->enqueueFolder(f);
-        }
-    } else {
-        qCWarning(lcEtagWatcher) << "Invalid empty etag received for" << f->displayName() << f->path();
-    }
 }

--- a/src/gui/scheduling/etagwatcher.h
+++ b/src/gui/scheduling/etagwatcher.h
@@ -32,8 +32,6 @@ public:
     ETagWatcher(FolderMan *folderMan, QObject *parent);
 
 private:
-    void updateEtag(Folder *f, const QString &etag);
-
     FolderMan *_folderMan;
 
     std::unordered_map<Folder *, QString> _lastEtagJob;


### PR DESCRIPTION
This change also resolves an issue where the etag was not normalized, and we scheduled folders too often

Fixes: #78