### PR TITLE
Remove ownCloudGui class forward declaration

### DIFF
--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -29,7 +29,6 @@ namespace Ui {
 class AccountSettings;
 class Application;
 class FolderMan;
-class ownCloudGui;
 class ActivitySettings;
 class GeneralSettings;
 


### PR DESCRIPTION
This PR removes `ownCloudGui` class forward declaration. 