### PR TITLE
docs: Add code comments explaining dual WebFinger calls

### DIFF
--- a/src/gui/newwizard/states/oauthcredentialssetupwizardstate.cpp
+++ b/src/gui/newwizard/states/oauthcredentialssetupwizardstate.cpp
@@ -59,8 +59,12 @@ OAuthCredentialsSetupWizardState::OAuthCredentialsSetupWizardState(SetupWizardCo
             }
         };
 
-        // we run this job here so that it runs during the transition state
-        // sure, it's not the cleanest ever approach, but currently it's good enough
+        // SECOND WEBFINGER CALL (authenticated):
+        // This discovers which OpenCloud instance(s) the authenticated user has access to.
+        // Uses the OAuth bearer token and resource="acct:me@{host}".
+        // Looking for: rel="http://webfinger.opencloud/rel/server-instance"
+        // See issue #271 for why we perform WebFinger twice.
+        // Backend WebFinger docs: https://github.com/opencloud-eu/opencloud/blob/main/services/webfinger/README.md
         if (!_context->accountBuilder().webFingerAuthenticationServerUrl().isEmpty()) {
             auto *job = Jobs::WebFingerInstanceLookupJobFactory(_context->accessManager(), token).startJob(_context->accountBuilder().serverUrl(), this);
 

--- a/src/gui/newwizard/states/serverurlsetupwizardstate.cpp
+++ b/src/gui/newwizard/states/serverurlsetupwizardstate.cpp
@@ -67,8 +67,12 @@ void ServerUrlSetupWizardState::evaluatePage()
             }
             _context->accountBuilder().setServerUrl(resolveJob->result().toUrl());
 
-            // check whether WebFinger is available
-            // therefore, we run the corresponding discovery job
+            // FIRST WEBFINGER CALL (unauthenticated):
+            // This discovers if the server supports WebFinger-based authentication
+            // and finds the IdP URL. The resource parameter is the server URL itself.
+            // Looking for: rel="http://openid.net/specs/connect/1.0/issuer"
+            // See issue #271 for why we perform WebFinger twice.
+            // Backend WebFinger docs: https://github.com/opencloud-eu/opencloud/blob/main/services/webfinger/README.md
             auto *checkWebFingerAuthJob =
                 Jobs::DiscoverWebFingerServiceJobFactory(_context->accessManager()).startJob(_context->accountBuilder().serverUrl(), this);
             connect(checkWebFingerAuthJob, &CoreJob::finished, this, [checkWebFingerAuthJob, this]() {


### PR DESCRIPTION
## Summary
- Added inline documentation to clarify the two WebFinger calls in the authentication flow
- Addresses confusion mentioned in #271

## Details
This PR adds code comments at both WebFinger call locations:
1. **First call** in `serverurlsetupwizardstate.cpp`: Unauthenticated call to discover IdP
2. **Second call** in `oauthcredentialssetupwizardstate.cpp`: Authenticated call to discover user's instance(s)

## Context
As discussed in #271, the dual WebFinger calls are intentional and serve different purposes in OpenCloud's multi-tenant architecture. These comments will help future contributors understand the design.

Fixes #271