### PR TITLE
Since Qt 6.8 network headers are normalized to lowercase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(APPLE_SUPPRESS_X11_WARNING ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-find_package(QT 6.7 NAMES Qt6 COMPONENTS Core REQUIRED)
+find_package(QT 6.8 NAMES Qt6 COMPONENTS Core REQUIRED)
 
 find_package(Qt6 COMPONENTS Core Concurrent Network Widgets Xml Quick QuickWidgets QuickControls2 REQUIRED)
 find_package(Qt6LinguistTools REQUIRED)

--- a/src/libsync/httplogger.cpp
+++ b/src/libsync/httplogger.cpp
@@ -104,10 +104,7 @@ void logHttp(const QByteArray &verb, HttpContext *ctx, QJsonObject &&header, QIO
 
     QJsonObject body = {{QStringLiteral("length"), contentLength}};
     if (contentLength > 0) {
-        QString contentType = header.value(QStringLiteral("Content-Type")).toString();
-        if (contentType.isEmpty()) {
-            contentType = header.value(QStringLiteral("content-type")).toString();
-        }
+        const QString contentType = header.value(QStringLiteral("Content-Type")).toString();
         if (isTextBody(contentType)) {
             if (!device->isOpen()) {
                 Q_ASSERT(dynamic_cast<QBuffer *>(device));

--- a/src/libsync/httplogger.cpp
+++ b/src/libsync/httplogger.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 
 using namespace std::chrono;
+using namespace Qt::Literals::StringLiterals;
 
 namespace {
 Q_LOGGING_CATEGORY(lcNetworkHttp, "sync.httplogger", QtWarningMsg)
@@ -70,7 +71,7 @@ void logHttp(const QByteArray &verb, HttpContext *ctx, QJsonObject &&header, QIO
     const auto contentLength = device ? device->size() : 0;
 
     if (redact) {
-        const QString authKey = QStringLiteral("Authorization");
+        const auto authKey = "authorization"_L1;
         const QString auth = header.value(authKey).toString();
         if (!auth.isEmpty()) {
             header.insert(authKey, auth.startsWith(QStringLiteral("Bearer ")) ? QStringLiteral("Bearer [redacted]") : QStringLiteral("Basic [redacted]"));
@@ -104,7 +105,7 @@ void logHttp(const QByteArray &verb, HttpContext *ctx, QJsonObject &&header, QIO
 
     QJsonObject body = {{QStringLiteral("length"), contentLength}};
     if (contentLength > 0) {
-        const QString contentType = header.value(QStringLiteral("Content-Type")).toString();
+        const QString contentType = header.value("content-type"_L1).toString();
         if (isTextBody(contentType)) {
             if (!device->isOpen()) {
                 Q_ASSERT(dynamic_cast<QBuffer *>(device));


### PR DESCRIPTION
This fixes a bug where we were not redacting the bearer token in the http logger.
https://bugreports.qt.io/browse/QTBUG-131474