### PR TITLE
Tests Only: fix add accounts step

### DIFF
--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -60,7 +60,7 @@ def create_user_sync_path(username):
         makedirs(user_sync_path)
 
     set_current_user_sync_path(user_sync_path)
-    return user_sync_path.replace('\\', '/')
+    return user_sync_path
 
 
 def create_space_path(username, space='Personal'):
@@ -68,7 +68,7 @@ def create_space_path(username, space='Personal'):
     space_path = join(user_sync_path, space, '')
     if not exists(space_path):
         makedirs(space_path)
-    return space_path.replace('\\', '/')
+    return space_path
 
 
 def set_current_user_sync_path(sync_path):
@@ -83,8 +83,6 @@ def get_resource_path(resource='', user='', space=''):
     sync_path = join(sync_path, space)
     sync_path = join(get_config('clientRootSyncPath'), sync_path)
     resource = resource.replace(sync_path, '').strip('/').strip('\\')
-    if is_windows():
-        resource = resource.replace('/', '\\')
     return join(
         sync_path,
         resource,

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -183,7 +183,7 @@ def filter_sync_messages(messages):
 def filter_messages_for_item(messages, item):
     filtered_messages = []
     for msg in messages:
-        msg = msg.rstrip('/').rstrip('\\').replace('\\', '/')
+        msg = msg.rstrip('/').rstrip('\\')
         item = item.rstrip('/').rstrip('\\')
         if msg.endswith(item):
             filtered_messages.append(msg)

--- a/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
@@ -1,6 +1,7 @@
 import test
 import names
 import squish
+import os
 
 from pageObjects.EnterPassword import EnterPassword
 
@@ -153,7 +154,7 @@ class AccountConnectionWizard:
             sync_path,
         )
         squish.clickButton(squish.waitForObject(AccountConnectionWizard.CHOOSE_BUTTON))
-        return sync_path
+        return os.path.join(sync_path, get_config('syncConnectionName'))
 
     @staticmethod
     def set_temp_folder_as_sync_folder(folder_name):

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -262,6 +262,9 @@ def step(context, sync_path, wizard):
     sync_path = substitute_inline_codes(sync_path)
 
     actual_sync_path = ''
+    if is_windows():
+        sync_path = sync_path.replace('/', '\\')
+        
     if wizard == 'configuration':
         actual_sync_path = AccountConnectionWizard.get_local_sync_path()
     else:

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -45,6 +45,10 @@ Feature: adding accounts
         When the user adds the server "%local_server%"
         And the user accepts the certificate
         Then credentials wizard should be visible
+        When the user adds the following account:
+            | user     | Alice |
+            | password | 1234  |
+        Then "Alice Hansen" account should be opened
 
 
     Scenario: Add space manually from sync connection window


### PR DESCRIPTION
- [x] Needs https://github.com/opencloud-eu/desktop/pull/282 be merged 

- Refactored path handling throughout for tests.
- **SetupClientHelper.py**
  - Removed forced conversion to forward slashes in `create_user_sync_path` and `create_space_path` returns; now returns native OS paths.
  - Eliminated Windows-specific slash replacement in `get_resource_path` for unified path formatting.
- **SyncHelper.py**
  - In `filter_messages_for_item`, stopped converting backslashes to slashes; now only trims trailing separators.
- **AccountConnectionWizard.py**
  - Appended `syncConnectionName` from config to sync folder path for correct folder (`space name like Personal` in general) selection.
- **account_context.py**
  - On Windows, replaced forward slashes with backslashes in `sync_path` before processing, because `/` is passed from the test step; ensuring platform compatibility