### PR TITLE
Test(refactor): Refactor the resources path for windows

### DIFF
--- a/test/gui/shared/scripts/helpers/FilesHelper.py
+++ b/test/gui/shared/scripts/helpers/FilesHelper.py
@@ -127,3 +127,14 @@ def cleanup_created_paths():
 def get_file_for_upload(file_name):
     base_upload_dir = get_config("files_for_upload")
     return os.path.join(base_upload_dir, file_name)
+
+
+def convert_path_separators_for_os(path):
+    """
+    Convert path separators to match the current operating system.
+    On Windows, converts forward slashes to backslashes.
+    On other systems, returns the path unchanged.
+    """
+    if is_windows():
+        return path.replace('/', '\\')
+    return path

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -17,7 +17,8 @@ from helpers.SyncHelper import (
     wait_for_initial_sync_to_complete,
     listen_sync_status_for_item,
 )
-from helpers.ConfigHelper import get_config, set_config, is_windows, is_linux
+from helpers.ConfigHelper import get_config, set_config, is_linux
+from helpers.FilesHelper import convert_path_separators_for_os
 
 
 @When('the user adds the following user credentials:')
@@ -262,8 +263,6 @@ def step(context, sync_path, wizard):
     sync_path = substitute_inline_codes(sync_path)
 
     actual_sync_path = ''
-    if is_windows():
-        sync_path = sync_path.replace('/', '\\')
         
     if wizard == 'configuration':
         actual_sync_path = AccountConnectionWizard.get_local_sync_path()
@@ -272,7 +271,7 @@ def step(context, sync_path, wizard):
 
     test.compare(
         actual_sync_path,
-        sync_path,
+        convert_path_separators_for_os(sync_path),
         'Compare sync path contains the expected path',
     )
 

--- a/test/gui/shared/steps/file_context.py
+++ b/test/gui/shared/steps/file_context.py
@@ -19,6 +19,7 @@ from helpers.FilesHelper import (
     get_size_in_bytes,
     prefix_path_namespace,
     remember_path,
+    convert_path_separators_for_os,
 )
 
 
@@ -43,9 +44,7 @@ def create_folder(foldername, username=None, is_temp_folder=False):
         folder_path = join(get_config('tempFolderPath'), foldername)
     else:
         folder_path = get_resource_path(foldername, username)
-    if is_windows:
-        folder_path = folder_path.replace('/', '\\')
-    os.makedirs(prefix_path_namespace(folder_path))
+    os.makedirs(prefix_path_namespace(convert_path_separators_for_os(folder_path)))
 
 
 def rename_file_folder(source, destination):
@@ -107,9 +106,7 @@ def add_copy_suffix(resource_path, resource_type):
 def step(context, username, filename):
     file_content = '\n'.join(context.multiLineText)
     file = get_resource_path(filename, username)
-    if is_windows:
-        file = file.replace('/', '\\')
-    wait_and_write_file(file, file_content)
+    wait_and_write_file(convert_path_separators_for_os(file), file_content)
 
 
 @When('user "|any|" creates a folder "|any|" inside the sync folder')

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -17,6 +17,7 @@ from helpers.SetupClientHelper import (
     substitute_inline_codes,
     get_resource_path,
 )
+from helpers.FilesHelper import convert_path_separators_for_os
 
 
 @Given('the user has paused the file sync')
@@ -42,9 +43,7 @@ def step(context):
 @When(r'the user waits for (file|folder) "([^"]*)" to be synced', regexp=True)
 def step(context, resource_type, resource):
     resource = get_resource_path(resource)
-    if is_windows:
-        resource = resource.replace('/', '\\')
-    wait_for_resource_to_sync(resource, resource_type)
+    wait_for_resource_to_sync(convert_path_separators_for_os(resource), resource_type)
 
 
 @When(r'the user waits for (file|folder) "([^"]*)" to have sync error', regexp=True)


### PR DESCRIPTION
This PR checks and refactors the path for windows os; replacing the path with the structure containing "/" to the one with "\\".
> [!NOTE] 
>**With these changes, the tests inside `tst_syncing` suite are all passing**
