### PR TITLE
Fix: request groups for oidc

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -337,7 +337,7 @@ QVector<quint16> Theme::oauthPorts() const
 
 QString Theme::openIdConnectScopes() const
 {
-    return QStringLiteral("openid offline_access email profile");
+    return QStringLiteral("openid offline_access email profile groups");
 }
 
 QString Theme::openIdConnectPrompt() const


### PR DESCRIPTION
Hi there,

I was frustrated to see that the desktop client doesn't support Authelia auth due to not requesting groups "permission". I added that, it's a tiny fix.

Fixes #217.

I have tested it with my local setup and seems to work fine.

Edit: if anyone wants to try, here's my [workflow artifacts](https://github.com/samolego/opencloud-desktop/actions/runs/15873831810)