### PR TITLE
showDowngradeDialog() appears not only on downgrades

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -171,7 +171,7 @@ void showDowngradeDialog()
 {
     QMessageBox box(QMessageBox::Warning, Theme::instance()->appNameGUI(),
         QCoreApplication::translate("version check",
-            "Some settings were configured in newer versions of this client "
+            "Some settings were configured in different versions of this client "
             "and use features that are not available in this version"));
     box.addButton(OCC::Application::tr("Quit"), QMessageBox::AcceptRole);
     box.exec();


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/41c02b21-1012-4e72-95a8-3037bc9a1650)

When the .cfg file was copied over from a nextcloud or owncloud client, this message may also happen. (To be expected).

The current language implies that we are an older version now, which is misleading.  Suggest to use something more neutral, e.g.  'different' instead.

See also: #344 