### PR TITLE
OAuth: Only display user name in an error if we have one

### DIFF
--- a/src/libsync/creds/idtoken.cpp
+++ b/src/libsync/creds/idtoken.cpp
@@ -16,6 +16,8 @@
 
 #include <QJsonArray>
 
+using namespace Qt::Literals::StringLiterals;
+
 using namespace OCC;
 
 IdToken::IdToken() { }
@@ -27,7 +29,7 @@ IdToken::IdToken(const QJsonObject &payload)
 
 QVariantList IdToken::aud() const
 {
-    const auto aud = _payload.value(QLatin1String("aud"));
+    const auto aud = _payload.value("aud"_L1);
     if (aud.isArray()) {
         return aud.toArray().toVariantList();
     }
@@ -36,12 +38,17 @@ QVariantList IdToken::aud() const
 
 QString IdToken::sub() const
 {
-    return _payload.value(QLatin1String("sub")).toString();
+    return _payload.value("sub"_L1).toString();
 }
 
 QString IdToken::preferred_username() const
 {
-    return _payload.value(QLatin1String("preferred_username")).toString();
+    return _payload.value("preferred_username"_L1).toString();
+}
+
+QString IdToken::name() const
+{
+    return _payload.value("name"_L1).toString();
 }
 
 bool IdToken::isValid() const

--- a/src/libsync/creds/idtoken.h
+++ b/src/libsync/creds/idtoken.h
@@ -28,6 +28,7 @@ public:
     QString sub() const;
 
     QString preferred_username() const;
+    QString name() const;
 
     bool isValid() const;
 


### PR DESCRIPTION
The OpenCloud build in idp does not provide a prefered_username
Fixes: #354 