### PR TITLE
Remove retry dep

### DIFF
--- a/.woodpecker/cache-opencloud.yaml
+++ b/.woodpecker/cache-opencloud.yaml
@@ -35,7 +35,7 @@ steps:
       - . ./.woodpecker.env
       - if $OPENCLOUD_CACHE_FOUND; then exit 0; fi
       - cd repo_opencloud
-      - retry -t 3 'make node-generate-prod'
+      - for i in $(seq 3); do make node-generate-prod && break || sleep 1; done
     image: owncloudci/nodejs:20
     name: generate-opencloud
   - commands:


### PR DESCRIPTION
## Description

Get rid of that small dependency. The current container has it, but if we change to an own container for nodejs we don't need to keep on maintaining that extra dependency.
Same as https://github.com/opencloud-eu/opencloud/commit/c897ec321fcd6af40c3dcfc56b2b6cd195a6054f


## Related Issue

Part of https://github.com/opencloud-eu/qa/issues/44
