### PR TITLE
Don't truncate inode on Windows

### DIFF
--- a/src/libsync/discoveryinfo.cpp
+++ b/src/libsync/discoveryinfo.cpp
@@ -35,7 +35,7 @@ OCC::LocalInfo::LocalInfo(const std::filesystem::directory_entry &dirent, ItemTy
         return;
     }
     isHidden = fileInfo.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN;
-    inode = ULARGE_INTEGER{{fileInfo.nFileIndexLow, fileInfo.nFileIndexHigh}}.QuadPart & 0x0000FFFFFFFFFFFF;
+    inode = ULARGE_INTEGER{{fileInfo.nFileIndexLow, fileInfo.nFileIndexHigh}}.QuadPart;
     size = ULARGE_INTEGER{{fileInfo.nFileSizeLow, fileInfo.nFileSizeHigh}}.QuadPart;
     modtime = FileSystem::fileTimeToTime_t(std::filesystem::file_time_type{
         std::filesystem::file_time_type::duration{ULARGE_INTEGER{fileInfo.ftLastWriteTime.dwLowDateTime, fileInfo.ftLastWriteTime.dwHighDateTime}.QuadPart}});


### PR DESCRIPTION
The inode will be updated locally, as the content didn't change we won't trigger an upload, just a CSYNC_INSTRUCTION_UPDATE_METADATA .
Move detection isn't affected as it was broke for years anyhow see #397 

Fixes: #396 