### PR TITLE
Test: remove redundant host parameter

### DIFF
--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -30,22 +30,20 @@ def step(context):
     )
 
 
-@Then('the account with displayname "|any|" and host "|any|" should be displayed')
-def step(context, displayname, _):
+@Then('the account with displayname "|any|" should be displayed')
+def step(context, displayname):
     displayname = substitute_inline_codes(displayname)
     Toolbar.account_exists(displayname)
 
 
-@Then('the account with displayname "|any|" and host "|any|" should not be displayed')
-def step(context, displayname, host):
+@Then('the account with displayname "|any|" should not be displayed')
+def step(context, displayname):
     displayname = substitute_inline_codes(displayname)
-    host = substitute_inline_codes(host)
-    account_title = displayname + '\n' + host
     timeout = get_config('lowestSyncTimeout') * 1000
 
     test.compare(
         False,
-        Toolbar.has_item(account_title, timeout),
+        Toolbar.has_item(displayname, timeout),
         f"Expected account '{displayname}' to be removed",
     )
 
@@ -159,8 +157,8 @@ def step(context, _):
     AccountSetting.wait_until_sync_folder_is_configured()
 
 
-@When('the user removes the connection for user "|any|" and host |any|')
-def step(context, username, _):
+@When('the user removes the connection for user "|any|"')
+def step(context, username):
     displayname = get_displayname_for_user(username)
     displayname = substitute_inline_codes(displayname)
 
@@ -263,7 +261,7 @@ def step(context, sync_path, wizard):
     sync_path = substitute_inline_codes(sync_path)
 
     actual_sync_path = ''
-        
+
     if wizard == 'configuration':
         actual_sync_path = AccountConnectionWizard.get_local_sync_path()
     else:

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -24,7 +24,7 @@ Feature: adding accounts
             | server   | %local_server% |
             | user     | Alice          |
             | password | 1234           |
-        Then the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
+        Then the account with displayname "Alice Hansen" should be displayed
 
 
     Scenario: Adding multiple accounts
@@ -36,8 +36,8 @@ Feature: adding accounts
             | user     | Brian          |
             | password | AaBb2Cc3Dd4    |
         Then "Brian Murphy" account should be opened
-        And the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
-        And the account with displayname "Brian Murphy" and host "%local_server_hostname%" should be displayed
+        And the account with displayname "Alice Hansen" should be displayed
+        And the account with displayname "Brian Murphy" should be displayed
 
 
     Scenario: Adding account with self signed certificate for the first time

--- a/test/gui/tst_removeAccountConnection/test.feature
+++ b/test/gui/tst_removeAccountConnection/test.feature
@@ -10,9 +10,9 @@ Feature: remove account connection
         And the user has set up the following accounts with default settings:
             | Alice |
             | Brian |
-        When the user removes the connection for user "Brian" and host %local_server_hostname%
-        Then the account with displayname "Brian Murphy" and host "%local_server_hostname%" should not be displayed
-        But the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
+        When the user removes the connection for user "Brian"
+        Then the account with displayname "Brian Murphy" should not be displayed
+        But the account with displayname "Alice Hansen" should be displayed
 
 
     Scenario: remove the only account connection
@@ -20,7 +20,7 @@ Feature: remove account connection
         And user "Alice" has created folder "large-folder" in the server
         And user "Alice" has uploaded file with content "test content" to "testFile.txt" in the server
         And user "Alice" has set up a client with default settings
-        When the user removes the connection for user "Alice" and host %local_server_hostname%
+        When the user removes the connection for user "Alice"
         Then the settings tab should have the following options in the general section:
             | Start on Login |
         And the folder "large-folder" should exist on the file system

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -428,7 +428,7 @@ Feature: Syncing files
             | password | 1234           |
         When the user selects manual sync folder option in advanced section
         And the user cancels the sync connection wizard
-        Then the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
+        Then the account with displayname "Alice Hansen" should be displayed
         And the sync folder list should be empty
 
 


### PR DESCRIPTION
## Summary
This PR removes the redundant `host` parameter from test step definitions

## Necessity
GUI tests run against a single test server (`%local_server_hostname%`). This redundancy adds unnecessary complexity to test steps. So removing this from places where it feels unnecessary