### PR TITLE
test(fix): fix hard failure while syncing personal space manually

### DIFF
--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -246,9 +246,9 @@ class SyncConnectionWizard:
 
     @staticmethod
     def sync_space(space_name):
+        SyncConnectionWizard.set_sync_path(get_current_user_sync_path())
         SyncConnectionWizard.select_space(space_name)
         SyncConnectionWizard.next_step()
-        SyncConnectionWizard.set_sync_path(get_current_user_sync_path())
         SyncConnectionWizard.add_sync_connection()
 
     @staticmethod

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -67,10 +67,10 @@ Feature: Syncing files
             | user     | Alice          |
             | password | 1234           |
         When the user selects manual sync folder option in advanced section
-        And the user selects "Personal" space in sync connection wizard
         And the user sets the sync path in sync connection wizard
         And the user navigates back in the sync connection wizard
         And the user sets the temp folder "localSyncFolder" as local sync path in sync connection wizard
+        And the user selects "Personal" space in sync connection wizard
         Then the sync all checkbox should be checked
         When user unselects all the remote folders
         And the user adds the folder sync connection
@@ -89,8 +89,8 @@ Feature: Syncing files
             | user     | Alice          |
             | password | 1234           |
         When the user selects manual sync folder option in advanced section
-        And the user selects "Personal" space in sync connection wizard
         And the user sets the sync path in sync connection wizard
+        And the user selects "Personal" space in sync connection wizard
         And the user selects the following folders to sync:
             | folder        |
             | simple-folder |
@@ -123,8 +123,8 @@ Feature: Syncing files
             | user     | Alice          |
             | password | 1234           |
         When the user selects manual sync folder option in advanced section
-        And the user selects "Personal" space in sync connection wizard
         And the user sets the sync path in sync connection wizard
+        And the user selects "Personal" space in sync connection wizard
         # folders are sorted by name in ascending order by default
         Then the folders should be in the following order:
             | folder    |
@@ -463,8 +463,8 @@ Feature: Syncing files
             | user     | Alice          |
             | password | 1234           |
         When the user selects manual sync folder option in advanced section
-        And the user selects "Personal" space in sync connection wizard
         And the user sets the temp folder "~`!@#$^&()-_=+{[}];',)PRN%" as local sync path in sync connection wizard
+        And the user selects "Personal" space in sync connection wizard
         And the user selects the following folders to sync:
             | folder                  |
             | ~`!@#$^&()-_=+{[}];',)  |


### PR DESCRIPTION
Fixes: https://github.com/opencloud-eu/desktop/issues/441

---
### On `Version 2.0.0.838`:

https://github.com/user-attachments/assets/52924b42-5f53-47d9-8583-6e10c1b81410

`Select the Personal space` &rarr; `Select sync path`


---

### But in recent version (`Version 3.0.0_git`):

https://github.com/user-attachments/assets/844320d5-67c4-4be0-93f2-fc3ef9ff191a

`Select sync path` &rarr; `Select the Personal space`

---
### What is fixed
In the existing test scenarios, selection of `Personal` space is happening before setting the `sync path` in sync connection wizard. This PR updates those scenarios to select the `Personal` space only after setting the `sync path`; which is the correct flow for manually syncing the Personal space as per above references (videos).