### PR TITLE
Also ignore all file names called desktop.ini*

### DIFF
--- a/src/libsync/csync_exclude.cpp
+++ b/src/libsync/csync_exclude.cpp
@@ -32,6 +32,7 @@
 #include <QFileInfo>
 #include <QString>
 
+using namespace Qt::Literals::StringLiterals;
 namespace {
 
 // See http://support.microsoft.com/kb/74496 and
@@ -214,8 +215,7 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(QStringView path, bool excludeC
 #endif
 
     /* Do not sync desktop.ini files anywhere in the tree. */
-    const auto desktopIniFile = QStringLiteral("desktop.ini");
-    if (blen == static_cast<qsizetype>(desktopIniFile.length()) && bname.compare(desktopIniFile, Qt::CaseInsensitive) == 0) {
+    if (bname.startsWith("desktop.ini"_L1, Qt::CaseInsensitive)) {
         return CSYNC_FILE_SILENTLY_EXCLUDED;
     }
 


### PR DESCRIPTION
Ignore changes to all files starting with "desktop.ini"

```
25-08-01 15:35:08:239 [ info gui.folderwatcher ]:	Detected changes in paths: QSet("C:/Users/hanna/OpenCloud Dev (27)/Shares/Desktop.ini.BjksIl", "C:/Users/hanna/OpenCloud Dev (27)/Shares/Desktop.ini.JmJeDU", "C:/Users/hanna/OpenCloud Dev (27)/Shares/Desktop.ini.lock")
25-08-01 15:35:08:239 [ debug sync.localdiscoverytracker ]	[ OCC::LocalDiscoveryTracker::addTouchedPath ]:	inserted touched "Desktop.ini.BjksIl"
25-08-01 15:35:08:239 [ debug sync.localdiscoverytracker ]	[ OCC::LocalDiscoveryTracker::addTouchedPath ]:	inserted touched "Desktop.ini.JmJeDU"
25-08-01 15:35:08:239 [ debug sync.localdiscoverytracker ]	[ OCC::LocalDiscoveryTracker::addTouchedPath ]:	inserted touched "Desktop.ini.lock
```
