### PR TITLE
fix: make translation source strings better readable

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -194,7 +194,7 @@ void AccountSettings::slotRemoveCurrentFolder(Folder *folder)
     // TODO: move to qml
     qCInfo(lcAccountSettings) << u"Remove Folder " << folder->path();
     auto messageBox = new QMessageBox(QMessageBox::Question, tr("Confirm removal of Space"),
-        tr("<p>Do you really want to stop syncing the Space <i>\"%1\"</i>?</p>"
+        tr("<p>Do you really want to stop syncing the Space »%1«?</p>"
            "<p><b>Note:</b> This will <b>not</b> delete any files.</p>")
             .arg(folder->displayName()),
         QMessageBox::NoButton, ocApp()->settingsDialog());
@@ -556,7 +556,7 @@ void AccountSettings::slotDeleteAccount()
     // Deleting the account potentially deletes 'this', so
     // the QMessageBox should be destroyed before that happens.
     auto messageBox = new QMessageBox(QMessageBox::Question, tr("Confirm Account Removal"),
-        tr("<p>Do you really want to remove the connection to the account <i>%1</i>?</p>"
+        tr("<p>Do you really want to remove the connection to the account %1«?</p>"
            "<p><b>Note:</b> This will <b>not</b> delete any files.</p>")
             .arg(_accountState->account()->displayNameWithHost()),
         QMessageBox::NoButton, this);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -186,7 +186,7 @@ void Application::slotAccountStateAdded(AccountStatePtr accountState) const
     connect(accountState->account().data(), &Account::serverVersionChanged, ocApp(), [account = accountState->account().data()] {
         if (account->serverSupportLevel() != Account::ServerSupportLevel::Supported) {
             ocApp()->systemNotificationManager()->notify({tr("Unsupported Server Version"),
-                tr("The server on account %1 runs an unsupported version %2. "
+                tr("The server on account »%1« runs an unsupported version %2. "
                    "Using this client with unsupported server versions is untested and "
                    "potentially dangerous. Proceed at your own risk.")
                     .arg(account->displayNameWithHost(), account->capabilities().status().versionString()),

--- a/src/gui/commonstrings.cpp
+++ b/src/gui/commonstrings.cpp
@@ -33,7 +33,7 @@ QString CommonStrings::showInFileBrowser(const QString &path)
     if (path.isEmpty()) {
         return tr("Show in %1").arg(fileBrowser());
     }
-    return tr("Show \"%1\" in %2").arg(path, fileBrowser());
+    return tr("Show »%1« in %2").arg(path, fileBrowser());
 }
 
 QString CommonStrings::showInWebBrowser()

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -153,7 +153,7 @@ Result<void, QString> Folder::checkPathLength(const QString &path)
 #ifdef Q_OS_WIN
     if (path.size() > MAX_PATH) {
         if (!FileSystem::longPathsEnabledOnWindows()) {
-            return tr("The path %1 is too long. Please enable long paths in the Windows settings or choose a different folder.").arg(path);
+            return tr("The path »%1« is too long. Please enable long paths in the Windows settings or choose a different folder.").arg(path);
         }
     }
 #else
@@ -195,19 +195,19 @@ bool Folder::checkLocalPath()
         if (error.isEmpty()) {
             qCDebug(lcFolder) << u"Checked local path ok";
             if (!_journal.open()) {
-                error = tr("Failed to open the database for %1.").arg(_definition.localPath());
+                error = tr("Failed to open the database for »%1«.").arg(_definition.localPath());
             }
         }
     } else {
         // Check directory again
         if (!FileSystem::fileExists(_definition.localPath(), fi)) {
-            error = tr("Local folder %1 does not exist.").arg(_definition.localPath());
+            error = tr("Local folder »%1« does not exist.").arg(_definition.localPath());
         } else if (!fi.isDir()) {
-            error = tr("%1 should be a folder but is not.").arg(_definition.localPath());
+            error = tr("»%1« should be a folder but is not.").arg(_definition.localPath());
         } else if (!fi.isReadable()) {
-            error = tr("%1 is not readable.").arg(_definition.localPath());
+            error = tr("»%1« is not readable.").arg(_definition.localPath());
         } else if (!fi.isWritable()) {
-            error = tr("%1 is not writable.").arg(_definition.localPath());
+            error = tr("»%1« is not writable.").arg(_definition.localPath());
         }
     }
     if (!error.isEmpty()) {
@@ -462,51 +462,51 @@ void Folder::createGuiLog(const QString &filename, LogStatus status, int count,
         switch (status) {
         case LogStatusRemove:
             if (count > 1) {
-                text = tr("%1 and %n other file(s) have been removed.", "", count - 1).arg(file);
+                text = tr("»%1« and %n other file(s) have been removed.", "", count - 1).arg(file);
             } else {
-                text = tr("%1 has been removed.", "%1 names a file.").arg(file);
+                text = tr("»%1« has been removed.", "%1 names a file.").arg(file);
             }
             break;
         case LogStatusNew:
             if (count > 1) {
-                text = tr("%1 and %n other file(s) have been added.", "", count - 1).arg(file);
+                text = tr("»%1« and %n other file(s) have been added.", "", count - 1).arg(file);
             } else {
-                text = tr("%1 has been added.", "%1 names a file.").arg(file);
+                text = tr("»%1« has been added.", "%1 names a file.").arg(file);
             }
             break;
         case LogStatusUpdated:
             if (count > 1) {
-                text = tr("%1 and %n other file(s) have been updated.", "", count - 1).arg(file);
+                text = tr("»%1« and %n other file(s) have been updated.", "", count - 1).arg(file);
             } else {
-                text = tr("%1 has been updated.", "%1 names a file.").arg(file);
+                text = tr("»%1« has been updated.", "%1 names a file.").arg(file);
             }
             break;
         case LogStatusRename:
             if (count > 1) {
-                text = tr("%1 has been renamed to %2 and %n other file(s) have been renamed.", "", count - 1).arg(file, renameTarget);
+                text = tr("»%1« has been renamed to »%2« and %n other file(s) have been renamed.", "", count - 1).arg(file, renameTarget);
             } else {
-                text = tr("%1 has been renamed to %2.", "%1 and %2 name files.").arg(file, renameTarget);
+                text = tr("»%1« has been renamed to »%2«.", "%1 and %2 name files.").arg(file, renameTarget);
             }
             break;
         case LogStatusMove:
             if (count > 1) {
-                text = tr("%1 has been moved to %2 and %n other file(s) have been moved.", "", count - 1).arg(file, renameTarget);
+                text = tr("»%1« has been moved to »%2« and %n other file(s) have been moved.", "", count - 1).arg(file, renameTarget);
             } else {
-                text = tr("%1 has been moved to %2.").arg(file, renameTarget);
+                text = tr("»%1« has been moved to »%2«.").arg(file, renameTarget);
             }
             break;
         case LogStatusConflict:
             if (count > 1) {
-                text = tr("%1 and %n other file(s) have sync conflicts.", "", count - 1).arg(file);
+                text = tr("»%1« and %n other file(s) have sync conflicts.", "", count - 1).arg(file);
             } else {
-                text = tr("%1 has a sync conflict. Please check the conflict file!").arg(file);
+                text = tr("»%1« has a sync conflict. Please check the conflict file!").arg(file);
             }
             break;
         case LogStatusError:
             if (count > 1) {
-                text = tr("%1 and %n other file(s) could not be synced due to errors. See the log for details.", "", count - 1).arg(file);
+                text = tr("»%1« and %n other file(s) could not be synced due to errors. See the log for details.", "", count - 1).arg(file);
             } else {
-                text = tr("%1 could not be synced due to an error. See the log for details.").arg(file);
+                text = tr("»%1« could not be synced due to an error. See the log for details.").arg(file);
             }
             break;
         }
@@ -713,7 +713,7 @@ void Folder::setVirtualFilesEnabled(bool enabled)
         };
         if (isSyncRunning()) {
             connect(this, &Folder::syncFinished, this, finalizeVfsSwitch, Qt::SingleShotConnection);
-            slotTerminateSync(tr("Switching VFS mode on folder '%1'").arg(displayName()));
+            slotTerminateSync(tr("Switching VFS mode on folder »%1«").arg(displayName()));
         } else {
             finalizeVfsSwitch();
         }
@@ -1077,14 +1077,14 @@ void Folder::warnOnNewExcludedItem(const SyncJournalFileRecord &record, QStringV
     if (!fi.exists())
         return;
 
-    const QString message = fi.isDir() ? tr("The folder %1 was created but was excluded from synchronization previously. "
+    const QString message = fi.isDir() ? tr("The folder »%1« was created but was excluded from synchronization previously. "
                                             "Data inside it will not be synchronized.")
                                              .arg(fi.filePath())
-                                       : tr("The file %1 was created but was excluded from synchronization previously. "
+                                       : tr("The file »%1« was created but was excluded from synchronization previously. "
                                             "It will not be synchronized.")
                                              .arg(fi.filePath());
 
-    ocApp()->systemNotificationManager()->notify({tr("%1 is not synchronized").arg(fi.fileName()), message, Resources::FontIcon(u'')});
+    ocApp()->systemNotificationManager()->notify({tr("»%1« is not synchronized").arg(fi.fileName()), message, Resources::FontIcon(u'')});
 }
 
 void Folder::slotWatcherUnreliable(const QString &message)

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -627,7 +627,7 @@ static QString checkPathForSyncRootMarkingRecursive(const QString &path, FolderM
     if (!existingTags.first.isEmpty()) {
         if (existingTags.first != Theme::instance()->orgDomainName()) {
             // another application uses this as spaces root folder
-            return FolderMan::tr("The folder %1 is already in use by application %2!").arg(path, existingTags.first);
+            return FolderMan::tr("The folder »%1« is already in use by application %2!").arg(path, existingTags.first);
         }
 
         // Looks good, it's our app, let's check the account tag:
@@ -640,7 +640,7 @@ static QString checkPathForSyncRootMarkingRecursive(const QString &path, FolderM
             [[fallthrough]];
         case FolderMan::NewFolderType::SpacesSyncRoot:
             // It's our application but we don't want to create a spaces folder, so it must be another space root
-            return FolderMan::tr("The folder %1 is already in use by another account.").arg(path);
+            return FolderMan::tr("The folder »%1« is already in use by another account.").arg(path);
         }
     }
 
@@ -677,7 +677,7 @@ QString FolderMan::checkPathValidityRecursive(const QString &path, FolderMan::Ne
     }
 
     if (numberOfSyncJournals(selectedPathInfo.filePath()) != 0) {
-        return FolderMan::tr("The folder %1 is used in a folder sync connection!").arg(QDir::toNativeSeparators(selectedPathInfo.filePath()));
+        return FolderMan::tr("The folder »%1« is used in a folder sync connection!").arg(QDir::toNativeSeparators(selectedPathInfo.filePath()));
     }
 
     // At this point we know there is no syncdb in the parent hyrarchy, check for spaces sync root.
@@ -715,13 +715,13 @@ QString FolderMan::checkPathValidityForNewFolder(const QString &path, NewFolderT
                       "Please pick another local folder!");
         }
         if (FileSystem::isChildPathOf(folderDir, userDir)) {
-            return tr("The local folder %1 already contains a folder used in a folder sync connection. "
+            return tr("The local folder »%1« already contains a folder used in a folder sync connection. "
                       "Please pick another local folder!")
                 .arg(QDir::toNativeSeparators(path));
         }
 
         if (FileSystem::isChildPathOf(userDir, folderDir)) {
-            return tr("The local folder %1 is already contained in a folder used in a folder sync connection. "
+            return tr("The local folder »%1« is already contained in a folder used in a folder sync connection. "
                       "Please pick another local folder!")
                 .arg(QDir::toNativeSeparators(path));
         }
@@ -729,7 +729,7 @@ QString FolderMan::checkPathValidityForNewFolder(const QString &path, NewFolderT
 
     const auto result = checkPathValidityRecursive(path, folderType, accountUuid);
     if (!result.isEmpty()) {
-        return tr("Please pick another local folder for %1.").arg(result);
+        return tr("Please pick another local folder for »%1«.").arg(result);
     }
     return {};
 }
@@ -790,7 +790,7 @@ Result<void, QString> FolderMan::unsupportedConfiguration(const QString &path) c
     if (it == _unsupportedConfigurationError.end()) {
         it = _unsupportedConfigurationError.insert(path, [&]() -> Result<void, QString> {
             if (numberOfSyncJournals(path) > 1) {
-                const QString error = tr("Multiple accounts are sharing the folder %1.\n"
+                const QString error = tr("Multiple accounts are sharing the folder »%1«.\n"
                                          "This configuration is know to lead to dataloss and is no longer supported.\n"
                                          "Please consider removing this folder from the account and adding it again.")
                                           .arg(path);

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -383,9 +383,9 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress, Folder *f)
             break;
         case ProgressInfo::Discovery:
             if (!progress._currentDiscoveredRemoteFolder.isEmpty()) {
-                pi->_overallSyncString = tr("Checking for changes in remote '%1'").arg(progress._currentDiscoveredRemoteFolder);
+                pi->_overallSyncString = tr("Checking for changes in remote »%1«").arg(progress._currentDiscoveredRemoteFolder);
             } else if (!progress._currentDiscoveredLocalFolder.isEmpty()) {
-                pi->_overallSyncString = tr("Checking for changes in local '%1'").arg(progress._currentDiscoveredLocalFolder);
+                pi->_overallSyncString = tr("Checking for changes in local »%1«").arg(progress._currentDiscoveredLocalFolder);
             }
             break;
         case ProgressInfo::Reconcile:

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -102,7 +102,7 @@ void Utility::markDirectoryAsSyncRoot(const QString &path, const QUuid &accountU
 
     auto result1 = FileSystem::Tags::set(path, dirTag(), Theme::instance()->orgDomainName().toUtf8());
     if (!result1) {
-        qCWarning(lcGuiUtility) << QStringLiteral("Failed to set tag on '%1': %2").arg(path, result1.error())
+        qCWarning(lcGuiUtility) << QStringLiteral("Failed to set tag on »%1«: %2").arg(path, result1.error())
 #ifdef Q_OS_WIN
                                 << QStringLiteral("(filesystem %1)").arg(FileSystem::fileSystemForPath(path))
 #endif // Q_OS_WIN
@@ -112,7 +112,7 @@ void Utility::markDirectoryAsSyncRoot(const QString &path, const QUuid &accountU
 
     auto result2 = FileSystem::Tags::set(path, uuidTag(), accountUuid.toString().toUtf8());
     if (!result2) {
-        qCWarning(lcGuiUtility) << QStringLiteral("Failed to set tag on '%1': %2").arg(path, result2.error())
+        qCWarning(lcGuiUtility) << QStringLiteral("Failed to set tag on »%1«: %2").arg(path, result2.error())
 #ifdef Q_OS_WIN
                                 << QStringLiteral("(filesystem %1)").arg(FileSystem::fileSystemForPath(path))
 #endif // Q_OS_WIN

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -108,7 +108,7 @@ void IgnoreListEditor::slotUpdateLocalIgnoreList()
         }
     } else {
         QMessageBox::warning(this, tr("Could not open file"),
-            tr("Cannot write changes to '%1'.").arg(ignoreFile));
+            tr("Cannot write changes to »%1«.").arg(ignoreFile));
     }
     ignores.close(); //close the file before reloading stuff.
 

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -205,7 +205,7 @@ IssuesWidget::IssuesWidget(QWidget *parent)
     connect(ProgressDispatcher::instance(), &ProgressDispatcher::excluded, this, [this](Folder *f, const QString &file) {
         auto item = SyncFileItemPtr::create(file);
         item->_status = SyncFileItem::FilenameReserved;
-        item->_errorString = tr("The file %1 was ignored as its name is reserved by %2").arg(file, Theme::instance()->appNameGUI());
+        item->_errorString = tr("The file »%1« was ignored as its name is reserved by %2").arg(file, Theme::instance()->appNameGUI());
         _model->addProtocolItem(ProtocolItem { f, item });
     });
 

--- a/src/gui/openfilemanager.cpp
+++ b/src/gui/openfilemanager.cpp
@@ -111,7 +111,7 @@ void showInFileManager(const QString &localPath)
     } else if (Utility::isMac()) {
         QStringList scriptArgs;
         scriptArgs << QStringLiteral("-e")
-                   << QStringLiteral("tell application \"Finder\" to reveal POSIX file \"%1\"")
+                   << QStringLiteral("tell application \"Finder\" to reveal POSIX file »%1«")
                           .arg(localPath);
         QProcess::execute(QStringLiteral("/usr/bin/osascript"), scriptArgs);
         scriptArgs.clear();

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -585,8 +585,8 @@ void SocketApi::command_DELETE_ITEM(const QString &localFile, SocketListener *)
     auto result = QMessageBox::question(
         nullptr, tr("Confirm deletion"),
         info.isDir()
-            ? tr("Do you want to delete the directory <i>%1</i> and all its contents permanently?").arg(info.dir().dirName())
-            : tr("Do you want to delete the file <i>%1</i> permanently?").arg(info.fileName()),
+            ? tr("Do you want to delete the directory »%1« and all its contents permanently?").arg(info.dir().dirName())
+            : tr("Do you want to delete the file »%1« permanently?").arg(info.fileName()),
         QMessageBox::Yes, QMessageBox::No);
     if (result != QMessageBox::Yes)
         return;

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -125,7 +125,7 @@ void Systray::slotComputeOverallSyncStatus()
     QStringList allStatusStrings;
     for (auto *folder : map) {
         QString folderMessage = FolderMan::trayTooltipStatusString(folder->syncResult(), folder->isSyncPaused());
-        allStatusStrings += tr("Folder %1: %2").arg(folder->shortGuiLocalPath(), folderMessage);
+        allStatusStrings += tr("Folder »%1«: %2").arg(folder->shortGuiLocalPath(), folderMessage);
     }
     trayMessage = allStatusStrings.join(QLatin1String("\n"));
 #endif

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -373,7 +373,7 @@ void WindowsUpdater::versionInfoArrived(const UpdateInfo &info)
 void WindowsUpdater::showNewVersionAvailableWidget(const UpdateInfo &info)
 {
     // if the version tag is set, there is a newer version.
-    QString txt = tr("<p>A new version of the %1 Desktop is available.</p>"
+    QString txt = tr("<p>A new version of the %1 Desktop App is available.</p>"
                      "<p><b>%2</b> is available for download. The installed version is %3.</p>")
                       .arg(Utility::escape(Theme::instance()->appNameGUI()),
                           Utility::escape(info.versionString()), Utility::escape(Version::versionWithBuildNumber().toString()));
@@ -406,7 +406,7 @@ void WindowsUpdater::showUpdateErrorDialog(const QString &targetVersion)
     ico->setFixedSize(iconSize, iconSize);
     ico->setPixmap(infoIcon.pixmap(iconSize));
     QLabel *lbl = new QLabel;
-    QString txt = tr("<p>A new version of the %1 Desktop is available but the updating process failed.</p>"
+    QString txt = tr("<p>A new version of the %1 Desktop App is available but the updating process failed.</p>"
                      "<p><b>%2</b> has been downloaded. The installed version is %3.</p>")
                       .arg(Utility::escape(Theme::instance()->appNameGUI()),
                           Utility::escape(targetVersion), Utility::escape(Version::versionWithBuildNumber().toString()));

--- a/src/libsync/appprovider.cpp
+++ b/src/libsync/appprovider.cpp
@@ -86,7 +86,7 @@ bool AppProvider::open(const AccountPtr &account, const QString &localPath, cons
                 qCDebug(lcAppProvider) << u"start browser" << url << result;
             } else {
                 Q_EMIT account->appProviderErrorOccured(
-                    QCoreApplication::translate("AppProvider", "Failed to open %1 in web. Error: %2.").arg(localPath, job->reply()->errorString()));
+                    QCoreApplication::translate("AppProvider", "Failed to open »%1« in web. Error: %2.").arg(localPath, job->reply()->errorString()));
             }
         });
         job->start();

--- a/src/libsync/common/filesystembase.cpp
+++ b/src/libsync/common/filesystembase.cpp
@@ -185,9 +185,9 @@ bool FileSystem::rename(const QString &originFileName, const QString &destinatio
     const QString originalFileNameLong = longWinPath(originFileName);
     const QString dest = longWinPath(destinationFileName);
     if (FileSystem::isFileLocked(dest, FileSystem::LockMode::Exclusive)) {
-        error = QCoreApplication::translate("FileSystem", "Can't rename %1, the file is currently in use").arg(destinationFileName);
+        error = QCoreApplication::translate("FileSystem", "Can't rename »%1«, the file is currently in use").arg(destinationFileName);
     } else if (FileSystem::isFileLocked(originalFileNameLong, FileSystem::LockMode::Exclusive)) {
-        error = QCoreApplication::translate("FileSystem", "Can't rename %1, the file is currently in use").arg(originFileName);
+        error = QCoreApplication::translate("FileSystem", "Can't rename »%1«, the file is currently in use").arg(originFileName);
     } else if (isLnkFile(originFileName) || isLnkFile(destinationFileName)) {
         success = MoveFileEx((wchar_t *)originalFileNameLong.utf16(), (wchar_t *)dest.utf16(), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH);
         if (!success) {
@@ -246,12 +246,12 @@ bool FileSystem::uncheckedRenameReplace(const QString &originFileName, const QSt
     const QString orig = longWinPath(originFileName);
     const QString dest = longWinPath(destinationFileName);
     if (FileSystem::isFileLocked(dest, FileSystem::LockMode::Exclusive)) {
-        *errorString = QCoreApplication::translate("FileSystem", "Can't rename %1, the file is currently in use").arg(destinationFileName);
+        *errorString = QCoreApplication::translate("FileSystem", "Can't rename »%1«, the file is currently in use").arg(destinationFileName);
         qCWarning(lcFileSystem) << u"Renaming failed: " << *errorString;
         return false;
     }
     if (FileSystem::isFileLocked(orig, FileSystem::LockMode::Exclusive)) {
-        *errorString = QCoreApplication::translate("FileSystem", "Can't rename %1, the file is currently in use").arg(originFileName);
+        *errorString = QCoreApplication::translate("FileSystem", "Can't rename »%1«, the file is currently in use").arg(originFileName);
         qCWarning(lcFileSystem) << u"Renaming failed: " << *errorString;
         return false;
     }

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -178,7 +178,7 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const QString &loc
         case CSYNC_FILE_EXCLUDE_RESERVED:
             qFatal("These were handled earlier");
         case CSYNC_FILE_EXCLUDE_LIST:
-            item->_errorString = tr("The fileis listed on the ignore list.");
+            item->_errorString = tr("The file is listed on the ignore list.");
             item->_status = SyncFileItem::Excluded;
             break;
         case CSYNC_FILE_EXCLUDE_INVALID_CHAR:
@@ -1255,7 +1255,7 @@ DiscoverySingleDirectoryJob *ProcessDirectoryJob::startAsyncServerQuery()
             }
             // Fatal for the root job since it has no SyncFileItem, or for the network errors
             Q_EMIT _discoveryData->fatalError(
-                tr("Server replied with an error while reading directory %1 : %2")
+                tr("Server replied with an error while reading directory »%1«: %2")
                     .arg(_currentFolder._server.isEmpty() ? QStringLiteral("/") : _currentFolder._server, results.error().message));
         }
     });

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -210,13 +210,13 @@ void DiscoverySingleLocalDirectoryJob::run() {
     }
     if (ec) {
         qCCritical(lcDiscovery) << u"Error while opening directory" << _localPath << ec.message();
-        QString errorString = tr("Error while opening directory %1").arg(_localPath);
+        QString errorString = tr("Error while opening directory »%1«").arg(_localPath);
         if (ec.value() == EACCES) {
             errorString = tr("Directory not accessible on client, permission denied");
             Q_EMIT finishedNonFatalError(errorString);
             return;
         } else if (ec.value() == ENOENT) {
-            errorString = tr("Directory not found: %1").arg(_localPath);
+            errorString = tr("Directory not found: »%1«").arg(_localPath);
         } else if (ec.value() == ENOTDIR) {
             // Not a directory..
             // Just consider it is empty

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -729,7 +729,7 @@ bool OwncloudPropagator::createConflict(const SyncFileItemPtr &item,
     if (FileSystem::isFileLocked(fn, FileSystem::LockMode::Exclusive)) {
         Q_EMIT seenLockedFile(fn, FileSystem::LockMode::Exclusive);
         if (error)
-            *error = tr("The file%1 is currently in use").arg(fn);
+            *error = tr("The file »%1« is currently in use").arg(fn);
         return false;
     }
 
@@ -1099,7 +1099,7 @@ void PropagateDirectory::slotSubJobsFinished(const SyncFileItem::Status status)
                     done(SyncFileItem::FatalError, tr("Error updating metadata: %1").arg(result.error()));
                     return;
                 } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-                    done(SyncFileItem::SoftError, tr("The folder %1 is currently in use").arg(_item->destination()));
+                    done(SyncFileItem::SoftError, tr("The folder »%1« is currently in use").arg(_item->destination()));
                     return;
                 }
             }
@@ -1111,7 +1111,7 @@ void PropagateDirectory::slotSubJobsFinished(const SyncFileItem::Status status)
     }
 
     // don't call done, we only propagate the state of the child items
-    // and we don't want error handling for this folder for an error that happend on a child
+    // and we don't want error handling for this folder for an error that happened on a child
     Q_ASSERT(state() != Finished);
     setState(Finished);
     Q_EMIT finished(status);
@@ -1282,7 +1282,7 @@ void OCC::PropagateUpdateMetaDataJob::start()
         done(SyncFileItem::FatalError, tr("Could not update file: %1").arg(result.error()));
         return;
     } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-        done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(_item->localName()));
+        done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(_item->localName()));
         return;
     }
     done(SyncFileItem::Success);

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -44,7 +44,7 @@ QString Progress::asResultString(const SyncFileItem &item)
     case CSYNC_INSTRUCTION_REMOVE:
         return QCoreApplication::translate("progress", "Deleted");
     case CSYNC_INSTRUCTION_RENAME:
-        return QCoreApplication::translate("progress", "%1 moved to %2").arg(item.localName(), item._renameTarget);
+        return QCoreApplication::translate("progress", "»%1« moved to »%2«").arg(item.localName(), item._renameTarget);
     case CSYNC_INSTRUCTION_IGNORE:
         return QCoreApplication::translate("progress", "Ignored");
     case CSYNC_INSTRUCTION_ERROR:

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -423,12 +423,12 @@ void PropagateDownloadFile::start()
     if (_item->_type == ItemTypeVirtualFileDehydration) {
         if (FileSystem::fileChanged(FileSystem::toFilesystemPath(fsPath), FileSystem::FileChangedInfo::fromSyncFileItemPrevious(_item.data()))) {
             propagator()->_anotherSyncNeeded = true;
-            done(SyncFileItem::SoftError, tr("The filehas changed since discovery"));
+            done(SyncFileItem::SoftError, tr("The file has changed since discovery"));
             return;
         }
         if (FileSystem::isFileLocked(fsPath, FileSystem::LockMode::Exclusive)) {
             Q_EMIT propagator()->seenLockedFile(fsPath, FileSystem::LockMode::Exclusive);
-            done(SyncFileItem::SoftError, tr("Failed to free up space, the file %1 is currently in use").arg(fsPath));
+            done(SyncFileItem::SoftError, tr("Failed to free up space, the file »%1« is currently in use").arg(fsPath));
             return;
         }
         qCDebug(lcPropagateDownload) << u"dehydrating file" << _item->localName();
@@ -454,7 +454,7 @@ void PropagateDownloadFile::start()
         // do a klaas' case clash check.
         if (auto clash = propagator()->localFileNameClash(_item->localName())) {
             done(SyncFileItem::NormalError,
-                tr("The file%1 can not be downloaded because of a local file name clash with %2!")
+                tr("The file »%1« can not be downloaded because of a local file name clash with %2!")
                     .arg(QDir::toNativeSeparators(_item->localName()), QDir::toNativeSeparators(clash.get())));
             return;
         }
@@ -537,7 +537,7 @@ void PropagateDownloadFile::startDownload()
     // do a klaas' case clash check.
     if (auto clash = propagator()->localFileNameClash(_item->localName())) {
         done(SyncFileItem::NormalError,
-            tr("The file%1 can not be downloaded because of a local file name clash with %2!")
+            tr("The file »%1« can not be downloaded because of a local file name clash with %2!")
                 .arg(QDir::toNativeSeparators(_item->localName()), QDir::toNativeSeparators(clash.get())));
         return;
     }
@@ -546,7 +546,7 @@ void PropagateDownloadFile::startDownload()
     const auto targetFile = propagator()->fullLocalPath(_item->localName());
     if (FileSystem::isFileLocked(targetFile, FileSystem::LockMode::Exclusive)) {
         Q_EMIT propagator()->seenLockedFile(targetFile, FileSystem::LockMode::Exclusive);
-        done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(QDir::toNativeSeparators(_item->localName())));
+        done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(QDir::toNativeSeparators(_item->localName())));
         return;
     }
     propagator()->reportProgress(*_item, 0);
@@ -694,7 +694,7 @@ void PropagateDownloadFile::slotGetFinished()
             // Range header should result in NormalError.
             job->setErrorStatus(SyncFileItem::SoftError);
         } else if (fileNotFound) {
-            job->setErrorString(tr("The filewas deleted from server"));
+            job->setErrorString(tr("The file was deleted from server"));
             job->setErrorStatus(SyncFileItem::SoftError);
 
             // As a precaution against bugs that cause our database and the
@@ -875,7 +875,7 @@ void PropagateDownloadFile::downloadFinished()
     // This can happen if another parallel download saved a clashing file.
     if (auto clash = propagator()->localFileNameClash(_item->localName())) {
         done(SyncFileItem::NormalError,
-            tr("The file%1 cannot be saved because of a local file name clash with %2!")
+            tr("The file »%1« cannot be saved because of a local file name clash with »%2«!")
                 .arg(QDir::toNativeSeparators(_item->localName()), QDir::toNativeSeparators(clash.get())));
         return;
     }
@@ -900,7 +900,7 @@ void PropagateDownloadFile::downloadFinished()
             done(SyncFileItem::NormalError, result.error());
             return;
         } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-            done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(_item->localName()));
+            done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(_item->localName()));
             return;
         }
     }
@@ -922,7 +922,7 @@ void PropagateDownloadFile::downloadFinished()
         // the discovery phase and now.
         if (FileSystem::fileChanged(FileSystem::toFilesystemPath(fn), FileSystem::FileChangedInfo::fromSyncFileItemPrevious(_item.data()))) {
             propagator()->_anotherSyncNeeded = true;
-            done(SyncFileItem::SoftError, tr("The filehas changed since discovery"));
+            done(SyncFileItem::SoftError, tr("The file has changed since discovery"));
             return;
         }
     }
@@ -930,7 +930,7 @@ void PropagateDownloadFile::downloadFinished()
     // becomes available again
     if (FileSystem::isFileLocked(fn, FileSystem::LockMode::Exclusive)) {
         Q_EMIT propagator()->seenLockedFile(fn, FileSystem::LockMode::Exclusive);
-        done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(fn));
+        done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(fn));
         return;
     }
 
@@ -965,7 +965,7 @@ void PropagateDownloadFile::updateMetadata(bool isConflict)
         done(SyncFileItem::FatalError, tr("Error updating metadata: %1").arg(result.error()));
         return;
     } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-        done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(_item->localName()));
+        done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(_item->localName()));
         return;
     }
     propagator()->_journal->setDownloadInfo(_item->localName(), SyncJournalDb::DownloadInfo());

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -147,7 +147,7 @@ void PropagateRemoteMove::finalize()
         done(SyncFileItem::FatalError, tr("Error updating metadata: %1").arg(result.error()));
         return;
     } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-        done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(newItem.localName()));
+        done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(newItem.localName()));
         return;
     }
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -123,7 +123,7 @@ void PropagateUploadFileCommon::start()
     // Check if the specific file can be accessed
     if (propagator()->hasCaseClashAccessibilityProblem(_item->localName())) {
         done(SyncFileItem::NormalError,
-            tr("The file%1 cannot be uploaded because another file with the same name, differing only in case, exists")
+            tr("The file »%1« cannot be uploaded because another file with the same name, differing only in case, exists")
                 .arg(QDir::toNativeSeparators(_item->localName())));
         return;
     }
@@ -174,7 +174,7 @@ void PropagateUploadFileCommon::slotComputeContentChecksum()
     // we must be able to read the file
     if (FileSystem::isFileLocked(filePath, FileSystem::LockMode::SharedRead)) {
         Q_EMIT propagator()->seenLockedFile(filePath, FileSystem::LockMode::SharedRead);
-        abortWithError(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(filePath));
+        abortWithError(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(filePath));
         return;
     }
 
@@ -205,7 +205,7 @@ void PropagateUploadFileCommon::slotComputeTransmissionChecksum(CheckSums::Algor
     // we must be able to read the file
     if (FileSystem::isFileLocked(filePath, FileSystem::LockMode::SharedRead)) {
         Q_EMIT propagator()->seenLockedFile(filePath, FileSystem::LockMode::SharedRead);
-        abortWithError(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(filePath));
+        abortWithError(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(filePath));
         return;
     }
 

--- a/src/libsync/propagateuploadtus.cpp
+++ b/src/libsync/propagateuploadtus.cpp
@@ -57,7 +57,7 @@ UploadDevice *PropagateUploadFileTUS::prepareDevice(const quint64 &chunkSize)
     // when it becomes available again.
     if (FileSystem::isFileLocked(localFileName, FileSystem::LockMode::SharedRead)) {
         Q_EMIT propagator()->seenLockedFile(localFileName, FileSystem::LockMode::SharedRead);
-        abortWithError(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(localFileName));
+        abortWithError(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(localFileName));
         return nullptr;
     }
     auto device = std::make_unique<UploadDevice>(localFileName, _currentOffset, chunkSize, propagator()->_bandwidthManager);

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -39,7 +39,7 @@ void PropagateUploadFileV1::doStartUpload()
     // when it becomes available again.
     if (FileSystem::isFileLocked(fileName, FileSystem::LockMode::SharedRead)) {
         Q_EMIT propagator()->seenLockedFile(fileName, FileSystem::LockMode::SharedRead);
-        abortWithError(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(QDir::toNativeSeparators(fileName)));
+        abortWithError(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(QDir::toNativeSeparators(fileName)));
         return;
     }
 

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -84,7 +84,7 @@ bool PropagateLocalRemove::removeRecursively(const QString &absolute)
             for (const auto &l : locked) {
                 // unlock is handled in hack in `void Folder::slotWatchedPathChanged`
                 Q_EMIT propagator()->seenLockedFile(l.path, FileSystem::LockMode::Exclusive);
-                errorList.append(tr("The file %1 is currently in use").arg(QDir::toNativeSeparators(l.path)));
+                errorList.append(tr("The file »%1« is currently in use").arg(QDir::toNativeSeparators(l.path)));
             }
             done(SyncFileItem::SoftError, errorList.join(QStringLiteral(", ")));
             return false;
@@ -104,14 +104,14 @@ void PropagateLocalRemove::start()
     qCDebug(lcPropagateLocalRemove) << filename;
 
     if (auto clash = propagator()->localFileNameClash(_item->localName())) {
-        done(SyncFileItem::NormalError, tr("Could not remove %1 because of a local file name clash with %2!").arg(QDir::toNativeSeparators(filename), QDir::toNativeSeparators(clash.get())));
+        done(SyncFileItem::NormalError, tr("Could not remove »%1« because of a local file name clash with »%2«!").arg(QDir::toNativeSeparators(filename), QDir::toNativeSeparators(clash.get())));
         return;
     }
 
     if (FileSystem::fileExists(filename)) {
         if (FileSystem::isFileLocked(filename, FileSystem::LockMode::Exclusive)) {
             Q_EMIT propagator()->seenLockedFile(filename, FileSystem::LockMode::Exclusive);
-            done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(QDir::toNativeSeparators(filename)));
+            done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(QDir::toNativeSeparators(filename)));
             return;
         }
 
@@ -120,7 +120,7 @@ void PropagateLocalRemove::start()
         if (_moveToTrash) {
             ok = QFile(filename).moveToTrash();
             if (!ok) {
-                removeError = tr("Could not move %1 to the trash bin").arg(filename);
+                removeError = tr("Could not move »%1« to the trash bin").arg(filename);
             }
         } else {
             if (_item->isDirectory()) {
@@ -160,7 +160,7 @@ void PropagateLocalMkdir::start()
             QString removeError;
             if (!FileSystem::remove(newDirStr, &removeError)) {
                 done(SyncFileItem::NormalError,
-                    tr("could not delete file %1, error: %2")
+                    tr("could not delete file »%1«, error: %2")
                         .arg(newDirStr, removeError));
                 return;
             }
@@ -175,12 +175,12 @@ void PropagateLocalMkdir::start()
 
     if (auto clash = propagator()->localFileNameClash(_item->localName())) {
         qCWarning(lcPropagateLocalMkdir) << u"New folder to create locally already exists with different case:" << _item->localName();
-        done(SyncFileItem::NormalError, tr("Can not create local folder %1 because of a local file name clash with %2").arg(newDirStr, QDir::toNativeSeparators(clash.get())));
+        done(SyncFileItem::NormalError, tr("Cannot create local folder »%1« because of a local file name clash with »%2«").arg(newDirStr, QDir::toNativeSeparators(clash.get())));
         return;
     }
     QDir localDir(propagator()->localPath());
     if (!localDir.mkpath(_item->localName())) {
-        done(SyncFileItem::NormalError, tr("could not create folder %1").arg(newDirStr));
+        done(SyncFileItem::NormalError, tr("Could not create folder »%1«").arg(newDirStr));
         return;
     }
 
@@ -196,7 +196,7 @@ void PropagateLocalMkdir::start()
         done(SyncFileItem::FatalError, tr("Error updating metadata: %1").arg(result.error()));
         return;
     } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-        done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(newItem.localName()));
+        done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(newItem.localName()));
         return;
     }
     propagator()->_journal->commit(QStringLiteral("localMkdir"));
@@ -231,13 +231,13 @@ void PropagateLocalRename::start()
             // Fixme: the file that is the reason for the clash could be named here,
             // it would have to come out the localFileNameClash function
             done(SyncFileItem::NormalError,
-                tr("The file%1 can not be renamed to %2 because of a local file name clash")
+                tr("The file »%1« can not be renamed to »%2« because of a local file name clash")
                     .arg(QDir::toNativeSeparators(_item->localName()), QDir::toNativeSeparators(_item->_renameTarget)));
             return;
         }
         if (FileSystem::isFileLocked(existingFile, FileSystem::LockMode::Exclusive)) {
             Q_EMIT propagator()->seenLockedFile(existingFile, FileSystem::LockMode::Exclusive);
-            done(SyncFileItem::SoftError, tr("Could not rename %1 to %2, the file is currently in use").arg(existingFile, targetFile));
+            done(SyncFileItem::SoftError, tr("Could not rename »%1« to »%2«, the file is currently in use").arg(existingFile, targetFile));
             return;
         }
         QString renameError;
@@ -262,7 +262,7 @@ void PropagateLocalRename::start()
             done(SyncFileItem::FatalError, tr("Error updating metadata: %1").arg(result.error()));
             return;
         } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
-            done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(newItem.localName()));
+            done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(newItem.localName()));
             return;
         }
     } else {

--- a/src/plugins/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/plugins/vfs/cfapi/cfapiwrapper.cpp
@@ -810,7 +810,7 @@ OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::up
         return OCC::Vfs::ConvertToPlaceholderResult::Ok;
     } else {
         if (result == HRESULT_FROM_WIN32(ERROR_NOT_A_CLOUD_FILE)) {
-            return u"%1 is not a cloud file"_s.arg(FileSystem::fromFilesystemPath(handle.path()));
+            return u"»%1« is not a cloud file"_s.arg(FileSystem::fromFilesystemPath(handle.path()));
         }
         const auto error = u"updatePlaceholderMarkInSync failed: %1"_s.arg(Utility::formatWinError(result));
         qCWarning(lcCfApiWrapper) << error;

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -114,7 +114,7 @@ private Q_SLOTS:
         auto oldRemoteState = fakeFolder.currentRemoteState();
 
         QString errorFolder = Utility::concatUrlPath(OCC::TestUtils::dummyDavUrl(), QStringLiteral("B")).path();
-        QString fatalErrorPrefix = QStringLiteral("Server replied with an error while reading directory 'B' : ");
+        QString fatalErrorPrefix = QStringLiteral("Server replied with an error while reading directory »B«: ");
         fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *) -> QNetworkReply * {
             if (req.attribute(QNetworkRequest::CustomVerbAttribute).toByteArray() == "PROPFIND" && req.url().path().endsWith(errorFolder)) {
                 if (errorKind == InvalidXML) {
@@ -155,7 +155,7 @@ private Q_SLOTS:
         // Check the same discovery error on the sync root
         //
         errorFolder = Utility::ensureTrailingSlash(OCC::TestUtils::dummyDavUrl().path());
-        fatalErrorPrefix = QStringLiteral("Server replied with an error while reading directory '/' : ");
+        fatalErrorPrefix = QStringLiteral("Server replied with an error while reading directory »/«: ");
         errorSpy.clear();
         QVERIFY(!fakeFolder.applyLocalModificationsAndSync());
         QCOMPARE(errorSpy.size(), 1);


### PR DESCRIPTION
Tried to create easier readable sentences from some translation source strings.

I discovered an inconsistency: file/folder names and paths were sometimes quoted with single quotes, sometimes not. Usually I think it's easier readable to quote file/folder names and paths. But the majority of string didn't have them quoted, so I removed the single quotes... ok to add the single quotes everywhere? In web we're using double arrows `»file name«` - should we use the same for desktop?