### PR TITLE
change help URL to the right docs URL

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -150,7 +150,7 @@ bool Theme::multiAccount() const
 
 QUrl Theme::helpUrl() const
 {
-    return QUrl(QStringLiteral("https://docs.opencloud.eu/docs/category/opencloud-desktop-1"));
+    return QUrl(QStringLiteral("https://docs.opencloud.eu/docs/user/desktop-client"));
 }
 
 QUrl Theme::updateCheckUrl() const


### PR DESCRIPTION
I changed the URL to the correct one who points to our docs for the Desktop Client