### PR TITLE
test: add test for re-adding removed account connection

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -1,6 +1,11 @@
 import names
 import squish
 
+from helpers.UserHelper import get_displayname_for_user
+from helpers.SetupClientHelper import substitute_inline_codes
+
+from pageObjects.Toolbar import Toolbar
+
 
 class AccountSetting:
     MANAGE_ACCOUNT_BUTTON = {
@@ -154,3 +159,10 @@ class AccountSetting:
         except:
             pass
         return visible
+
+    @staticmethod
+    def remove_connection_for_user(username):
+        displayname = get_displayname_for_user(username)
+        displayname = substitute_inline_codes(displayname)
+        Toolbar.open_account(displayname)
+        AccountSetting.remove_account_connection()

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -1,3 +1,6 @@
+import shutil
+import os
+
 from pageObjects.AccountConnectionWizard import AccountConnectionWizard
 from pageObjects.SyncConnectionWizard import SyncConnectionWizard
 from pageObjects.EnterPassword import EnterPassword
@@ -159,11 +162,7 @@ def step(context, _):
 
 @When('the user removes the connection for user "|any|"')
 def step(context, username):
-    displayname = get_displayname_for_user(username)
-    displayname = substitute_inline_codes(displayname)
-
-    Toolbar.open_account(displayname)
-    AccountSetting.remove_account_connection()
+    AccountSetting.remove_connection_for_user(username)
 
 
 @Then('connection wizard should be visible')
@@ -282,3 +281,9 @@ def step(context, warn_message):
         warn_message in actual_message,
         'Contains warning message',
     )
+
+
+@Given('the user has removed the connection for user "|any|"')
+def step(context, username):
+    AccountSetting.remove_connection_for_user(username)
+    shutil.rmtree(os.path.join(get_config("clientRootSyncPath"), username))

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -75,3 +75,18 @@ Feature: adding accounts
         Then the default local sync path should contain "%home%/OpenCloud (2)" in the configuration wizard
         When the user selects download everything option in advanced section
         Then the button to open sync connection wizard should be disabled
+        
+    @skipOnWindows @issue-435
+    Scenario: Re-add an account
+        Given user "Alice" has created folder "large-folder" in the server
+        And user "Alice" has uploaded file with content "test content" to "testFile.txt" in the server
+        And user "Alice" has set up a client with default settings
+        And the user has removed the connection for user "Alice"
+        When the user opens the add-account dialog
+        And the user adds the following account:
+            | server   | %local_server% |
+            | user     | Alice          |
+            | password | 1234           |
+        Then the account with displayname "Alice Hansen" should be displayed
+        And the folder "large-folder" should exist on the file system
+        And the file "testFile.txt" should exist on the file system


### PR DESCRIPTION
This PR adds:
```gherkin
Scenario: Re-add an account
```
scenario for test of re-adding an account connection that has been removed. `skipOnWindows` tag is used because of above the issue mentioned below for windows OS. When that issue gets resolved then that tag can be removed.

---

Related issue: https://github.com/opencloud-eu/desktop/issues/435
