### PR TITLE
Use offscree platform plugin for tests on Windows

### DIFF
--- a/test/opencloud_add_test.cmake
+++ b/test/opencloud_add_test.cmake
@@ -23,7 +23,7 @@ function(opencloud_add_test test_class)
     add_dependencies(${_test_target_name} test_helper)
 
     target_include_directories(${_test_target_name} PRIVATE "${CMAKE_SOURCE_DIR}/test/")
-    if (UNIX AND NOT APPLE)
+    if ((UNIX AND NOT APPLE) OR WIN32)
         set_property(TEST ${_test_target_name} PROPERTY ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
     endif()
 endfunction()

--- a/test/opencloud_add_test.cmake
+++ b/test/opencloud_add_test.cmake
@@ -24,6 +24,6 @@ function(opencloud_add_test test_class)
 
     target_include_directories(${_test_target_name} PRIVATE "${CMAKE_SOURCE_DIR}/test/")
     if ((UNIX AND NOT APPLE) OR WIN32)
-        set_property(TEST ${_test_target_name} PROPERTY ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+        set_property(TEST ${_test_target_name} PROPERTY ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_LOGGING_RULES=*=true")
     endif()
 endfunction()


### PR DESCRIPTION
Ideally, we would only use it if we are running in docker, but there is still no great way to determine if one runs in docker...