### PR TITLE
test: add test for checking status of shares removed by sharee

### DIFF
--- a/test/gui/shared/scripts/helpers/ConfigHelper.py
+++ b/test/gui/shared/scripts/helpers/ConfigHelper.py
@@ -101,7 +101,8 @@ CONFIG = {
 
 # Permission roles mapping
 PERMISSION_ROLES = {
-    'Viewer': 'b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5'
+    'Viewer': 'b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5',
+    'Editor': 'fb6c3e19-e378-47e5-b277-9732f9de6e21'
 }
 
 CONFIG.update(DEFAULT_PATH_CONFIG)

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -66,3 +66,18 @@ Feature: Project spaces
         When the user removes the folder sync connection
         Then the sync folder list should be empty
         But the file "testfile.txt" should exist on the file system
+
+
+    Scenario: Sharee removes the shared resources
+        Given user "Brian" has been created in the server with default attributes
+        And user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has uploaded file with content "test content" to "simple-folder/uploaded-lorem.txt" in the server
+        And user "Alice" has sent the following resource share invitation:
+            | resource        | simple-folder |
+            | sharee          | Brian         |
+            | permissionsRole | Editor        |
+        And user "Brian" has set up a client with space "Shares"
+        When user "Brian" deletes the folder "Shares/simple-folder" in the server
+        And the user waits for the files to sync
+        Then the folder "simple-folder" should not exist on the file system
+        Then the folder "simple-folder/uploaded-lorem.txt" should not exist on the file system


### PR DESCRIPTION
This PR adds a test coverage for checking if the resources deleted in the server by a `sharee` with `editor` permission role are also deleted in the local file system:
```gherkin
Scenario: Sharee removes the shared resources
```