### PR TITLE
Test: add test for multibyte characters in filename

### DIFF
--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -525,3 +525,16 @@ Feature: Syncing files
             | resource                 | status      | account                              |
             | simple-folder/sub-folder | Blacklisted | Brian Murphy@%local_server_hostname% |
             | simple-folder/simple.pdf | Blacklisted | Brian Murphy@%local_server_hostname% |
+
+    @skipOnWindows @issue-435
+    Scenario Outline: File with long multi-byte characters name can be synced (76 characters, 255 bytes including extension)
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
+            """
+            test content
+            """
+        And the user waits for file "<filename>" to be synced
+        Then as "Alice" file "<filename>" should exist in the server
+        Examples:
+            | filename                                                                    |
+            | 𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺abôǣฎพฒฆ๘ตกกผพฒณญไใๅำ๊๒๔๗๘รศฬอฮ.txt |


### PR DESCRIPTION
This PR adds a scenario for testing if the multi-byte characters in the resource name are read properly or not:
```gherkin
    Scenario Outline: File with long multi-byte characters name can be synced (76 characters, 255 bytes including extension)
        Given user "Alice" has set up a client with default settings
        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
            """
            test content
            """
        And the user waits for file "<filename>" to be synced
        Then as "Alice" file "<filename>" should exist in the server
        Examples:
            | filename                                                                                                                                                  |
            | 𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺abôǣฎพฒฆ๘ตกกผพฒณญไใๅำ๊๒๔๗๘รศฬอฮ.txt |

```

The characters seems like empty box in GH preview but exact format can be found when you view after clicking `Edit` here in github. Also I am sharing screenshot to illustrate the exact format used in the test:
<img width="1448" height="249" alt="image" src="https://github.com/user-attachments/assets/099827e1-b5ad-4f61-a80d-4ef64cb2fa7c" />


Locally the test passes, lets see in CI