### PR TITLE
test(refactor): make pnpm command os independent

### DIFF
--- a/test/gui/shared/scripts/helpers/WebUIHelper.py
+++ b/test/gui/shared/scripts/helpers/WebUIHelper.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import squish
-from helpers.ConfigHelper import is_windows
 
 
 def get_clipboard_text():
@@ -25,7 +24,7 @@ def authorize_via_webui(username, password, login_type='oidc'):
         'OC_AUTH_URL': get_clipboard_text(),
     }
     proc = subprocess.run(
-        f"{'pnpm.exe' if is_windows() else 'pnpm'} run {login_type}-login",
+        f"pnpm run {login_type}-login",
         capture_output=True,
         shell=True,
         env={**os.environ, **envs},


### PR DESCRIPTION
This PR makes the execution of pnpm command OS independent. Let user decide to install pnpm (or any pakage manager) however they want but they must be sure that package manager is executable in their terminal 