### PR TITLE
ci: upload and show html gui test reports

### DIFF
--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -10,7 +10,7 @@ variables:
       from_secret: cache_s3_secret_key
     CACHE_BUCKET:
       from_secret: cache_s3_bucket
-    MC_HOST: "https://s3.ci.opencloud.eu"
+    MC_HOST: 'https://s3.ci.opencloud.eu'
     PUBLIC_BUCKET: public
 
 depends_on:
@@ -68,7 +68,7 @@ steps:
       - ./opencloud server
     detach: true
     environment:
-      FRONTEND_SEARCH_MIN_LENGTH: "2"
+      FRONTEND_SEARCH_MIN_LENGTH: '2'
       GRAPH_AVAILABLE_ROLES: b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6,63e64e19-8d43-42ec-a738-2b6af2610efa
       IDM_ADMIN_PASSWORD: admin
       LDAP_GROUP_SUBSTRING_FILTER_TYPE: any
@@ -103,7 +103,7 @@ steps:
       - mkdir /woodpecker/desktop/test/gui/clientLog -p
       - chmod 777 /woodpecker/desktop/test/gui/ -R
 
-  - name: monitor-server-logs
+  - name: squish-server-logs
     image: *ubuntu_image
     detach: true
     commands:
@@ -131,19 +131,39 @@ steps:
   - name: crash-log
     image: *ubuntu_image
     when:
-      - status: [ success, failure ]
+      - status: [success, failure]
     commands:
       - cat /woodpecker/desktop/test/gui/tmp/OpenCloud-crash.log 2>/dev/null || exit 0
+
+  - name: upload-test-reports
+    environment:
+      <<: *minio_environment
+    image: *minio_image
+    when:
+      - status: [failure]
+    commands:
+      - mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+      - mc cp -a -r /woodpecker/desktop/test/gui/clientLog/* s3/$PUBLIC_BUCKET/desktop/$CI_PIPELINE_NUMBER/logs/
+      - mc cp -a -r /woodpecker/desktop/test/gui/guiReportUpload s3/$PUBLIC_BUCKET/desktop/$CI_PIPELINE_NUMBER
+
+  - name: gui-test-reports
+    environment:
+      <<: *minio_environment
+    image: *minio_image
+    when:
+      - status: [failure]
+    commands:
+      - mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+      - bash test/gui/woodpecker/gui_test_reports.sh
 
   - name: client-log
     environment:
       <<: *minio_environment
     image: *minio_image
     when:
-      - status: [ success, failure ]
+      - status: [failure]
     commands:
       - mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
-      - mc cp -a --recursive /woodpecker/desktop/test/gui/clientLog/* s3/$PUBLIC_BUCKET/desktop/$CI_PIPELINE_NUMBER/logs/
       - cd /woodpecker/desktop/test/gui/clientLog/
       - echo "To download the logs, access the following links:"
       - logs=$(mc find s3/$PUBLIC_BUCKET/desktop/$CI_PIPELINE_NUMBER/logs/)

--- a/test/gui/woodpecker/gui_test_reports.sh
+++ b/test/gui/woodpecker/gui_test_reports.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+REPORT_PATH="$PUBLIC_BUCKET/desktop/$CI_PIPELINE_NUMBER/guiReportUpload"
+REPORT_URL="$MC_HOST/$REPORT_PATH"
+
+echo ""
+echo "--- GUI Test Reports ---"
+echo "GUI Test Report: $REPORT_URL/index.html"
+
+screenshots=$(mc find s3/$REPORT_PATH/screenshots/ 2>/dev/null || true)
+if [[ -n "$screenshots" ]]; then
+  echo "Screenshots:"
+  for f in $screenshots; do
+    # remove 's3/' prefix
+    f=${f/s3\//}
+    echo "  - $MC_HOST/$f"
+  done
+else
+  echo "No screenshots found."
+fi


### PR DESCRIPTION
Upload and show GUI html test reports and screenshots.

Resolves https://github.com/opencloud-eu/desktop/issues/659

Step logs:
```
+ mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
Added `s3` successfully.
+ bash test/gui/woodpecker/gui_test_reports.sh
--- GUI Test Reports ---
GUI Test Report: https://s3.ci.opencloud.eu/public/desktop/320/guiReportUpload/index.html
No screenshots found.
```
```
+ mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
Added `s3` successfully.
+ bash test/gui/woodpecker/gui_test_reports.sh
--- GUI Test Reports ---
GUI Test Report: https://s3.ci.opencloud.eu/public/desktop/322/guiReportUpload/index.html
Screenshots:
  - https://s3.ci.opencloud.eu/public/desktop/322/guiReportUpload/screenshots/filter_not_synced_activities_(Linux_only).png
```