### PR TITLE
Disable assert for deleted files in move detection

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -516,7 +516,7 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(
                     // If the file exist or if there is another error, consider it is a new file.
                     postProcessServerNew();
                     return;
-                } else if (OC_ENSURE(job->httpStatusCode() == 404)) {
+                } else if (job->httpStatusCode() == 404) {
                     // The file do not exist, it is a rename
 
                     // In case the deleted item was discovered in parallel


### PR DESCRIPTION
We have error handling in case a deleted item was discovered in parallel,
but it is unreachable if OC_ENSURE() explodes first.