### PR TITLE
fix(tests): Add delay to stabilize file sync conflict test

### DIFF
--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -312,3 +312,8 @@ def step(context):
         expected_error_message,
         f'Expected error message: "{expected_error_message}" but got: "{actual_error_message}"'
     )
+
+
+@Given('the user has waited for "|any|" seconds')
+def step(context, wait_for):
+    squish.snooze(float(wait_for))

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -43,6 +43,7 @@ Feature: Syncing files
             client content
             """
         And user "Alice" has uploaded file with content "changed server content" to "/conflict.txt" in the server
+        And the user has waited for "5" seconds
         When the user resumes the file sync on the client
         And the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity


### PR DESCRIPTION
The test scenario `Syncing a file from the server and creating a conflict` is flaky due to a race condition.

  The client's file watcher requires a brief moment to detect local file changes made by the test script. If the sync resumes immediately, the sync process can start  before the client is aware of the local change, leading to a failure in detecting the intended conflict.

  This change introduces a 5-second delay to make the test robust. The delay is strategically placed immediately before the sync is resumed. This placement is critical, as  it ensures the client has the correct state information before it begins the synchronization that will lead to the conflict.

  Placing the delay any later (e.g., before the final assertion) would be ineffective, as the sync would have already completed and the conflict would have been missed.

**The sequence needs to be:**

Upload to server → WAIT (let server settle) → Resume sync (engine detects conflict) → Check UI

Not:

Upload to server → Resume sync (engine might miss conflict) → WAIT → Check UI (shows no conflict)

---
Failing CIs: 
- https://ci.opencloud.eu/repos/11/pipeline/190/46#L1215
- https://ci.opencloud.eu/repos/11/pipeline/192/46#L1660
