### PR TITLE
Use standard include for QML_ELEMENT

### DIFF
--- a/src/libsync/globalconfig.h
+++ b/src/libsync/globalconfig.h
@@ -6,7 +6,7 @@
 #include "libsync/opencloudsynclib.h"
 
 #include <QVariant>
-#include <QtQmlMeta>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 namespace OCC {
 class OPENCLOUD_SYNC_EXPORT GlobalConfig : public QObject


### PR DESCRIPTION
QtQmlMeta is a weird semi-internal include that is not really supposed to be used, and here it's only used to transitively pull in QML_ELEMENT and friends. Qt 6.10.1 makes it no longer public, so the build now fails. Fix it by using the include you're supposed to be using according to Qt docs.