### PR TITLE
Test: Fix Windows test cleanup to prevent subsequent test failures

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -17,6 +17,7 @@
 # manual for a complete reference of the available API.
 import shutil
 import os
+import squish
 from datetime import datetime
 from types import SimpleNamespace
 
@@ -180,23 +181,34 @@ def teardown_client():
     # Cleanup user accounts from UI for Windows platform
     # It is not needed for Linux so skipping it in order to save CI time
     if is_windows():
-        # remove account from UI
-        # In Windows, removing only config and sync folders won't help
-        # so to work around that, remove the account connection
-        close_dialogs()
-        close_widgets()
-        active_widget = get_active_widget()
-        if active_widget.objectName != names.setupWizardWindow_OCC_Wizard_SetupWizardWindow["name"]:
-            accounts, selectors = Toolbar.get_accounts()
-            for display_name in selectors:
-                _, account_objects = Toolbar.get_accounts()
-                squish.mouseClick(squish.waitForObject(account_objects[display_name]))
-                AccountSetting.remove_account_connection()
+        try:
+            close_dialogs()
+            close_widgets()
 
-            # re-fetch accounts after removing from UI
-            accounts, _ = Toolbar.get_accounts()
-            if accounts:
-                squish.waitForObject(AccountConnectionWizard.SERVER_ADDRESS_BOX)
+            # remove account from UI
+            # In Windows, removing only config and sync folders won't help
+            # so to work around that, remove the account connection
+            # Navigate to main page via stack widget to access toolbar
+            dialog_stack = squish.waitForObject(AccountSetting.DIALOG_STACK, get_config('minSyncTimeout') * 1000)
+            if hasattr(dialog_stack, 'setCurrentIndex'):
+                dialog_stack.setCurrentIndex(0)
+
+            squish.waitForObject(Toolbar.TOOLBAR_ROW, get_config('minSyncTimeout') * 1000)
+
+            # Remove all accounts
+            accounts, selectors = Toolbar.get_accounts()
+            for display_name in list(selectors.keys()):
+                try:
+                    _, account_objects = Toolbar.get_accounts()
+                    if display_name in account_objects:
+                        squish.mouseClick(squish.waitForObject(account_objects[display_name]))
+                        AccountSetting.remove_account_connection()
+                except Exception as e:
+                    test.log(f"Warning: Could not remove account {display_name}: {e}")
+                    continue
+
+        except Exception as e:
+            test.log(f"Error during Windows cleanup: {e}")
 
     # Detach (i.e. potentially terminate) all AUTs at the end of a scenario
     for ctx in squish.applicationContextList():


### PR DESCRIPTION
#### Problem
Tests were getting stuck at UI steps (e.g., "choose local download directory", "About page", "Version page"), leaving the application in an inconsistent state. Like in some scenarios the AUT doesn't get closed so that the clean up does not happen properly.
For example, Scenario: Check default options in advanced configuration:

https://github.com/user-attachments/assets/9961a087-4597-4ffd-9952-ab53e2bd03ee


```
Log Closing 'QFileDialog' window November 3, 2025 at 11:56:10 AM +05:45 C:\Users\vboxuser\projects\desktop\test\gui\shared\scripts\bdd_hooks.py:232

Detail Object '{container={container={name='dialogStack' type='QStackedWidget' visible='1' window={name='Settings' type='OCC::SettingsDialog' visible='1'}} name='quickWidget' type='OCC::QmlUtils::OCQuickWidget' visible='1'} type='RowLayout' visible='true'}' not found. Could not match properties:
    container for object name: '{container={container={name='dialogStack' type='QStackedWidget' visible='1' window=:settings_OCC_SettingsDialog} name='quickWidget' type='OCC::QmlUtils::OCQuickWidget' visible='1'} type='RowLayout' visible='true'}'
    type for object name: '{name='dialogStack' type='QStackedWidget' visible='1' window=:settings_OCC_SettingsDialog}'  C:\Users\vboxuser\projects\desktop\test\gui\shared\scripts\pageObjects\Toolbar.py:110
```
<img width="1918" height="917" alt="image" src="https://github.com/user-attachments/assets/731af897-be11-47f7-8259-25dbf9f49675" />

As we can see `Toolbar` is not found due to which the clean up does not happen properly. And when we run test again, we get the access denied error


#### Solution
Force navigation to the main screen before cleanup:

```python
dialog_stack = squish.waitForObject(AccountSetting.DIALOG_STACK, get_config('minSyncTimeout') * 1000)
if hasattr(dialog_stack, 'setCurrentIndex'):
    dialog_stack.setCurrentIndex(0)  # Go to main screen before cleanup