### PR TITLE
test: remove skipOnWindows and related issue tag

### DIFF
--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -76,7 +76,7 @@ Feature: adding accounts
         When the user selects download everything option in advanced section
         Then the button to open sync connection wizard should be disabled
 
-    @skipOnWindows @issue-435
+
     Scenario: Re-add an account
         Given user "Alice" has created folder "large-folder" in the server
         And user "Alice" has uploaded file with content "test content" to "testFile.txt" in the server

--- a/test/gui/tst_deleteFilesFolders/test.feature
+++ b/test/gui/tst_deleteFilesFolders/test.feature
@@ -65,7 +65,7 @@ Feature: deleting files and folders
             | textfile1.txt |
         And as "Alice" file "textfile2.txt" should exist in the server
 
-	@issue-435
+
     Scenario: Create and delete a file with special characters in the filename
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "~`!@#$^&()-_=+{[}];',$%ñ&💥🫨❤️‍🔥.txt" with the following content inside the sync folder

--- a/test/gui/tst_moveFilesFolders/test.feature
+++ b/test/gui/tst_moveFilesFolders/test.feature
@@ -67,7 +67,7 @@ Feature: move file and folder
         And as "Alice" file "folder1/file2.txt" should not exist in the server
 
 
-    @issue-435
+
     Scenario: Move resources from different sub-levels to sync root
         Given user "Alice" has created folder "folder1/folder2/folder3/folder4/test-folder" in the server
         And user "Alice" has uploaded file with content "openCloud" to "folder1/folder2/lorem.txt" in the server
@@ -80,7 +80,7 @@ Feature: move file and folder
         And as "Alice" file "folder1/folder2/lorem.txt" should not exist in the server
         And as "Alice" folder "folder1/folder2/folder3/folder4/test-folder" should not exist in the server
 
-    @issue-435
+
 	Scenario: Syncing a 50MB file moved into the local sync folder
         Given user "Alice" has set up a client with default settings
         And user "Alice" has created a folder "Folder1" inside the sync folder

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -67,7 +67,7 @@ Feature: Project spaces
         Then the sync folder list should be empty
         But the file "testfile.txt" should exist on the file system
 
-    @issue-435
+
     Scenario: User with Viewer role cannot create resource
         Given the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with space "Project101"
@@ -82,7 +82,7 @@ Feature: Project spaces
             | resource      | status      | account                              |
             | simple-folder | Blacklisted | Alice Hansen@%local_server_hostname% |
 
-    @issue-435
+
     Scenario: Sharee with Editor role deletes the shared resource
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "simple-folder" in the server

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -404,7 +404,7 @@ Feature: Syncing files
         And the user waits for file "file with space.txt" to be synced
         Then as "Alice" file "file with space.txt" should exist in the server
 
-    @issue-435
+
     Scenario: Syncing folders each having large number of files
         Given the user has created a folder "folder1" in temp folder
         And the user has created "500" files each of size "1048576" bytes inside folder "folder1" in temp folder
@@ -533,7 +533,7 @@ Feature: Syncing files
             | simple-folder/sub-folder | Blacklisted | Brian Murphy@%local_server_hostname% |
             | simple-folder/simple.pdf | Blacklisted | Brian Murphy@%local_server_hostname% |
 
-    @skipOnWindows @issue-435
+
     Scenario Outline: File with long multi-byte characters name can be synced (76 characters, 255 bytes including extension)
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "<filename>" with the following content inside the sync folder
@@ -546,7 +546,7 @@ Feature: Syncing files
             | filename                                                                    |
             | 𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺abôǣฎพฒฆ๘ตกกผพฒณญไใๅำ๊๒๔๗๘รศฬอฮ.txt |
 
-    @issue-435
+
 	Scenario: Sync a received shared folder with Editor permission role
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "simple-folder" in the server
@@ -566,7 +566,7 @@ Feature: Syncing files
         And as "Brian" file "Shares/simple-folder/simple.pdf" should exist in the server
         And as "Brian" the file "Shares/simple-folder/uploaded-lorem.txt" should have the content "overwrite openCloud test text file" in the server
 
-    @issue-435
+
     Scenario: Unselected subfolders are excluded from local sync
         Given user "Alice" has created folder "test-folder" in the server
         And user "Alice" has created folder "test-folder/sub-folder1" in the server


### PR DESCRIPTION
This PR removes the `@skipOnWindows` and `@issue-435` tag from related scenarios because the root cause of problem was not in the desktop client. It was in the test code itself. Fixed by : https://github.com/opencloud-eu/desktop/pull/584