### PR TITLE
🎉 Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug Fixes
 
+- Ensure downloads are closed before finished is emitted [[#741](https://github.com/opencloud-eu/desktop/pull/741)]
+- Fix autostart on linux [[#740](https://github.com/opencloud-eu/desktop/pull/740)]
 - Fix massive ram usage with http2 downloads [[#736](https://github.com/opencloud-eu/desktop/pull/736)]
 - Fix high cpu usage during cfapi hydration [[#735](https://github.com/opencloud-eu/desktop/pull/735)]
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.0.3` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-3.0` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.0.3](https://github.com/opencloud-eu/desktop/releases/tag/v3.0.3) - 2025-12-03

### 🐛 Bug Fixes

- Ensure downloads are closed before finished is emitted [[#741](https://github.com/opencloud-eu/desktop/pull/741)]
- Fix autostart on linux [[#740](https://github.com/opencloud-eu/desktop/pull/740)]
- Fix massive ram usage with http2 downloads [[#736](https://github.com/opencloud-eu/desktop/pull/736)]
- Fix high cpu usage during cfapi hydration [[#735](https://github.com/opencloud-eu/desktop/pull/735)]