### PR TITLE
fix(ci): use woodpecker ci url from secret

### DIFF
--- a/.woodpecker/notification.yaml
+++ b/.woodpecker/notification.yaml
@@ -3,6 +3,8 @@ variables:
   - &qa_repo 'https://github.com/opencloud-eu/qa.git'
   - &qa_repo_branch 'main'
   - &current_repo_id '11'
+  - &ci_woodpecker_url
+    from_secret: oc_ci_url
 
 depends_on: [build, ui-tests]
 runs_on: [ success, failure ]
@@ -31,7 +33,7 @@ steps:
         from_secret: opencloud-notifications-user-password
       QA_REPO: *qa_repo
       QA_REPO_BRANCH: *qa_repo_branch
-      CI_WOODPECKER_URL: https://ci.opencloud.eu/
+      CI_WOODPECKER_URL: *ci_woodpecker_url
       CI_REPO_ID: *current_repo_id
       CI_WOODPECKER_TOKEN: no-auth-needed-on-this-repo
 


### PR DESCRIPTION
Replaces the old  Woodpecker server URL used by the Notification Service with the value from secret
Part of: https://github.com/opencloud-eu/qa/issues/76
Notification pipeline passed: https://ci.opencloud.rocks/repos/11/pipeline/46