### PR TITLE
chore(deps): update playwright/test to 1.57.0

### DIFF
--- a/test/gui/webUI/package.json
+++ b/test/gui/webUI/package.json
@@ -5,7 +5,7 @@
         "oidc-login": "playwright test --grep @oidc"
     },
     "devDependencies": {
-        "@playwright/test": "1.45.0"
+        "@playwright/test": "^1.57.0"
     },
     "packageManager": "pnpm@8.15.8"
 }

--- a/test/gui/webUI/pnpm-lock.yaml
+++ b/test/gui/webUI/pnpm-lock.yaml
@@ -1,44 +1,52 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-devDependencies:
-  '@playwright/test':
-    specifier: 1.45.0
-    version: 1.45.0
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
 
 packages:
 
-  /@playwright/test@1.45.0:
-    resolution: {integrity: sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==}
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
-    dependencies:
-      playwright: 1.45.0
-    dev: true
 
-  /fsevents@2.3.2:
+  fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    dev: true
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
+  fsevents@2.3.2:
     optional: true
 
-  /playwright-core@1.45.0:
-    resolution: {integrity: sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: true
+  playwright-core@1.57.0: {}
 
-  /playwright@1.45.0:
-    resolution: {integrity: sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==}
-    engines: {node: '>=18'}
-    hasBin: true
+  playwright@1.57.0:
     dependencies:
-      playwright-core: 1.45.0
+      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true


### PR DESCRIPTION
Playwright's version < `1.55.1` has a severe security vulnerability: https://github.com/advisories/GHSA-7mvr-c777-76hp - High Severity

Dependabot alert: https://github.com/opencloud-eu/desktop/security/dependabot/1

Playwright's browser installer scripts used curl -k (insecure flag) to download and install browsers without validating SSL certificates. This allowed attackers to perform Man-in-the-Middle attacks and deliver malicious executable.

Affected versions: `playwright < 1.55.1`
Fixed in: `playwright >= 1.55.1` https://github.com/microsoft/playwright/pull/37532