### PR TITLE
test(ci): skip test related pipelines for ready-release-go PRs

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -40,6 +40,8 @@ when:
       - push
       - manual
   - event: pull_request
+    evaluate: |
+      !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: tag
   - event: cron
     cron: nightly*

--- a/.woodpecker/cache-opencloud.yaml
+++ b/.woodpecker/cache-opencloud.yaml
@@ -63,6 +63,8 @@ when:
       - push
       - manual
   - event: pull_request
+    evaluate: |
+      !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: tag
   - event: cron
     cron: nightly*

--- a/.woodpecker/cache-pnpm.yaml
+++ b/.woodpecker/cache-pnpm.yaml
@@ -59,6 +59,8 @@ when:
       - manual
   - event: tag
   - event: pull_request
+    evaluate: |
+      !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: cron
     cron: nightly*
 workspace:

--- a/.woodpecker/cache-python.yaml
+++ b/.woodpecker/cache-python.yaml
@@ -51,6 +51,8 @@ when:
       - manual
   - event: tag
   - event: pull_request
+    evaluate: |
+      !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: cron
     cron: nightly*
 workspace:

--- a/.woodpecker/purge-cache.yaml
+++ b/.woodpecker/purge-cache.yaml
@@ -15,6 +15,8 @@ when:
   - event: [push, manual]
     branch: ${CI_REPO_DEFAULT_BRANCH}
   - event: pull_request
+    evaluate: |
+      !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: cron
     cron: nightly*
 


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/qa/issues/47
This PR adds the logic to skip test related pipelines for release PRs generated by the `ready-release-go` plugin. 
I have targetted the creator of the PR which is always `openclouders` for release PRs and also targetted the branch which happens to be `next-release/main` or `next-release/stable-*`.

To make sure the targetted branch works, i have created following two dummy PRs. Check their CI(Running only `build` pipeline just to test):

1. PR with branch `next-release/test-only` : https://github.com/opencloud-eu/desktop/pull/759
    CI: https://ci.opencloud.rocks/repos/11/pipeline/171
2. PR with branch `next-release/stable-10.1` : https://github.com/opencloud-eu/desktop/pull/760
    CI: https://ci.opencloud.rocks/repos/11/pipeline/172
    
    
##
:exclamation:  Note: With this PR's change, no pipelines will run in the CI for the release PRs