### PR TITLE
feat(oauth): support desktop-specific OIDC issuer and `client_id` discovery

### DIFF
--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -90,7 +90,7 @@ AccountPtr SetupWizardAccountBuilder::build() const
     // TODO: perhaps _authenticationStrategy->setUpAccountPtr(...) would be more elegant? no need for getters then
     newAccountPtr->setCredentials(_authenticationStrategy->makeCreds());
     newAccountPtr->credentials()->persist();
-    OAuth::persist(newAccountPtr, _authenticationStrategy->dynamicRegistrationData(), _authenticationStrategy->idToken());
+    OAuth::persist(newAccountPtr, _authenticationStrategy->dynamicRegistrationData(), _authenticationStrategy->idToken(), _webFingerDesktopClientId);
 
     newAccountPtr->setDavDisplayName(_displayName);
 
@@ -164,6 +164,16 @@ void SetupWizardAccountBuilder::setWebFingerAuthenticationServerUrl(const QUrl &
 QUrl SetupWizardAccountBuilder::webFingerAuthenticationServerUrl() const
 {
     return _webFingerAuthenticationServerUrl;
+}
+
+void SetupWizardAccountBuilder::setWebFingerDesktopClientId(const QString &clientId)
+{
+    _webFingerDesktopClientId = clientId;
+}
+
+QString SetupWizardAccountBuilder::webFingerDesktopClientId() const
+{
+    return _webFingerDesktopClientId;
 }
 
 void SetupWizardAccountBuilder::setWebFingerInstances(const QVector<QUrl> &instancesList)

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -98,6 +98,9 @@ public:
     void setWebFingerAuthenticationServerUrl(const QUrl &url);
     QUrl webFingerAuthenticationServerUrl() const;
 
+    void setWebFingerDesktopClientId(const QString &clientId);
+    QString webFingerDesktopClientId() const;
+
     void setWebFingerInstances(const QVector<QUrl> &instancesList);
     QVector<QUrl> webFingerInstances() const;
 
@@ -108,6 +111,7 @@ private:
     QUrl _serverUrl;
 
     QUrl _webFingerAuthenticationServerUrl;
+    QString _webFingerDesktopClientId;
     QVector<QUrl> _webFingerInstances;
     QUrl _webFingerSelectedInstance;
 

--- a/src/gui/newwizard/states/oauthcredentialssetupwizardstate.cpp
+++ b/src/gui/newwizard/states/oauthcredentialssetupwizardstate.cpp
@@ -30,6 +30,14 @@ OAuthCredentialsSetupWizardState::OAuthCredentialsSetupWizardState(SetupWizardCo
     }();
 
     auto oAuth = new OAuth(authServerUrl, _context->accessManager(), {}, this);
+
+    // Use the desktop-specific client_id if provided by webfinger
+    // See: https://github.com/opencloud-eu/desktop/issues/246
+    const QString desktopClientId = _context->accountBuilder().webFingerDesktopClientId();
+    if (!desktopClientId.isEmpty()) {
+        oAuth->setClientId(desktopClientId);
+    }
+
     _page = new OAuthCredentialsSetupWizardPage(oAuth, authServerUrl);
 
 

--- a/src/gui/newwizard/states/serverurlsetupwizardstate.cpp
+++ b/src/gui/newwizard/states/serverurlsetupwizardstate.cpp
@@ -81,7 +81,13 @@ void ServerUrlSetupWizardState::evaluatePage()
                 if (!checkWebFingerAuthJob->success()) {
                     Q_EMIT evaluationSuccessful();
                 } else {
-                    _context->accountBuilder().setWebFingerAuthenticationServerUrl(checkWebFingerAuthJob->result().toUrl());
+                    // Result is now a QVariantMap with "issuer" and "clientId" keys
+                    const auto resultMap = checkWebFingerAuthJob->result().toMap();
+                    _context->accountBuilder().setWebFingerAuthenticationServerUrl(resultMap.value(QStringLiteral("issuer")).toUrl());
+                    const QString clientId = resultMap.value(QStringLiteral("clientId")).toString();
+                    if (!clientId.isEmpty()) {
+                        _context->accountBuilder().setWebFingerDesktopClientId(clientId);
+                    }
                     Q_EMIT evaluationSuccessful();
                 }
             });

--- a/src/libsync/creds/oauth.h
+++ b/src/libsync/creds/oauth.h
@@ -79,7 +79,14 @@ public:
     QString clientId() const;
     QString clientSecret() const;
 
-    static void persist(const AccountPtr &accountPtr, const QVariantMap &dynamicRegistrationData, const IdToken &idToken);
+    /**
+     * Set a custom client_id to use instead of the theme default.
+     * This is used when the server provides a desktop-specific client_id via webfinger.
+     * Must be called before startAuthentication().
+     */
+    void setClientId(const QString &clientId);
+
+    static void persist(const AccountPtr &accountPtr, const QVariantMap &dynamicRegistrationData, const IdToken &idToken, const QString &desktopClientId = {});
 
 Q_SIGNALS:
     /**


### PR DESCRIPTION
fix #246

Enables identity providers that require separate OIDC clients per application type (like Authentik, Kanidm, Zitadel) to work with the desktop client.

- Discover desktop-specific OIDC issuer via WebFinger (`http://openid.net/specs/connect/1.0/issuer/desktop`)
- Use server-provided `client_id` from WebFinger link properties when available
- Persist and restore `client_id` across re-authentication

## Server-side changes

To work, this PR requires changes in https://github.com/opencloud-eu/opencloud. 
A complementary PR is available at https://github.com/opencloud-eu/opencloud/pull/2072.

Additionally, the following env vars must be set on the admin side:

```
WEBFINGER_OIDC_ISSUER_DESKTOP: <>
WEBFINGER_OIDC_CLIENT_ID_DESKTOP: <>
```

Here, `WEBFINGER_OIDC_ISSUER_DESKTOP` is usually the root URL of the identity provider and `WEBFINGER_OIDC_CLIENT_ID_DESKTOP` contains the `client_id` of the respective oAuth project.

---

With these changes, I was able to login into the Desktop app with a dedicated oAuth project through Zitadel (v4.7.0). The implementation should be generic and work with other oAuth providers as well.