### PR TITLE
Modernise proxy lookup and meassure its duration

### DIFF
--- a/src/gui/clientproxy.h
+++ b/src/gui/clientproxy.h
@@ -33,23 +33,7 @@ class ConfigFile;
  */
 namespace ClientProxy {
     bool isUsingSystemDefault();
-    void lookupSystemProxyAsync(const QUrl &url, QObject *dst, const char *slot);
     void setupQtProxyFromConfig(const QString &password);
-
-    QString printQNetworkProxy(const QNetworkProxy &proxy);
-};
-
-class SystemProxyRunnable : public QObject, public QRunnable
-{
-    Q_OBJECT
-public:
-    SystemProxyRunnable(const QUrl &url);
-    void run() override;
-Q_SIGNALS:
-    void systemProxyLookedUp(const QNetworkProxy &url);
-
-private:
-    QUrl _url;
 };
 }
 

--- a/src/gui/connectionvalidator.h
+++ b/src/gui/connectionvalidator.h
@@ -64,8 +64,6 @@ public Q_SLOTS:
     /// Checks the server and the authentication.
     void checkServer(ConnectionValidator::ValidationMode mode = ConnectionValidator::ValidationMode::ValidateAuthAndUpdate);
 
-    void systemProxyLookupDone(const QNetworkProxy &proxy);
-
 Q_SIGNALS:
     void connectionResult(ConnectionValidator::Status status, const QStringList &errors);
 


### PR DESCRIPTION
```
26-02-09 14:34:20:555 [ info sync.connectionvalidator ]:	System proxy lookup done NoProxy """:0" ["Tunnel Listen UDP SctpTunnel SctpListen"] for "Test@opencloud..de" duration(0h, 0min, 0s, 251ms)
```