### PR TITLE
FetchServerSettingsJob always emit finished

### DIFF
--- a/src/gui/fetchserversettings.cpp
+++ b/src/gui/fetchserversettings.cpp
@@ -67,9 +67,8 @@ void FetchServerSettingsJob::start()
             }
             _account->setCapabilities({_account->url(), caps.toVariantMap()});
             runAsyncUpdates();
-
-            Q_EMIT finishedSignal();
         }
+        Q_EMIT finishedSignal();
     });
     job->start();
 }


### PR DESCRIPTION
This only partly solves what is going on in #819.
I can't really see why we are getting `26-02-23 19:55:01:730 [ info sync.connectionvalidator ]:	ConnectionValidator "Myname@cloud.local" still running after duration(0h, 0min, 29s, 977ms)` when we get a response to the graph api request.