### PR TITLE
ci(woodpecker): trigger gui tests workflow only on related file changes

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -9,6 +9,20 @@ variables:
     CACHE_BUCKET:
       from_secret: cache_s3_bucket
     MC_HOST: 'https://s3.ci.opencloud.eu'
+  - &trigger_path
+    include:
+      - test/gui/**
+      - src/**
+      - cmake/**
+      - THEME.cmake
+      - VERSION.cmake
+      - CMakeLists.txt
+      - OPENCLOUD.cmake
+      - .woodpecker/**
+    exclude:
+      - .woodpecker/ready-release-go.yaml
+      - .woodpecker/translation.yaml
+      - test/gui/manual-test-plan
 
 when:
   - branch:
@@ -17,7 +31,11 @@ when:
     event:
       - push
       - manual
+    path:
+      <<: *trigger_path
   - event: pull_request
+    path:
+      <<: *trigger_path
     evaluate: |
       !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: tag

--- a/.woodpecker/cache-pnpm.yaml
+++ b/.woodpecker/cache-pnpm.yaml
@@ -8,6 +8,20 @@ variables:
     CACHE_BUCKET:
       from_secret: cache_s3_bucket
     MC_HOST: 'https://s3.ci.opencloud.eu'
+  - &trigger_path
+    include:
+      - test/gui/**
+      - src/**
+      - cmake/**
+      - THEME.cmake
+      - VERSION.cmake
+      - CMakeLists.txt
+      - OPENCLOUD.cmake
+      - .woodpecker/**
+    exclude:
+      - .woodpecker/ready-release-go.yaml
+      - .woodpecker/translation.yaml
+      - test/gui/manual-test-plan
 
 when:
   - branch:
@@ -16,8 +30,12 @@ when:
     event:
       - push
       - manual
+    path:
+      <<: *trigger_path
   - event: tag
   - event: pull_request
+    path:
+      <<: *trigger_path
     evaluate: |
       !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: cron

--- a/.woodpecker/cache-python.yaml
+++ b/.woodpecker/cache-python.yaml
@@ -9,6 +9,20 @@ variables:
     CACHE_BUCKET:
       from_secret: cache_s3_bucket
     MC_HOST: 'https://s3.ci.opencloud.eu'
+  - &trigger_path
+    include:
+      - test/gui/**
+      - src/**
+      - cmake/**
+      - THEME.cmake
+      - VERSION.cmake
+      - CMakeLists.txt
+      - OPENCLOUD.cmake
+      - .woodpecker/**
+    exclude:
+      - .woodpecker/ready-release-go.yaml
+      - .woodpecker/translation.yaml
+      - test/gui/manual-test-plan
 
 when:
   - branch:
@@ -17,8 +31,12 @@ when:
     event:
       - push
       - manual
+    path:
+      <<: *trigger_path
   - event: tag
   - event: pull_request
+    path:
+      <<: *trigger_path
     evaluate: |
       !(CI_COMMIT_SOURCE_BRANCH matches "next-release/(main|stable-*)" && CI_COMMIT_AUTHOR == "openclouders")
   - event: cron

--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -25,8 +25,9 @@ when:
     cron: nightly*
 
 depends_on:
-  - cache-pnpm
   - build
+  - cache-pnpm
+  - cache-python
 
 workspace:
   base: /woodpecker


### PR DESCRIPTION
Run gui tests workflow only if the related files are changes. This prevents running the full gui tests on docs and translation  only commits and PRs
```
include:
  - test/gui/**
  - src/**
  - cmake/**
  - THEME.cmake
  - VERSION.cmake
  - CMakeLists.txt
  - OPENCLOUD.cmake
  - .woodpecker/**
exclude:
  - .woodpecker/ready-release-go.yaml
  - .woodpecker/translation.yaml
  - test/gui/manual-test-plan
```