### PR TITLE
build: build qtbase with a11y bridge from source

### DIFF
--- a/.craft.ini
+++ b/.craft.ini
@@ -60,6 +60,7 @@ dev-utils/msys.ignored = True
 dev-utils/gtk-doc.ignored = True
 
 #libs/qt6.version = ${Variables:QtVersion}
+libs/qt6/qtbase.featureArguments = -DQT_FEATURE_accessibility=ON -DQT_FEATURE_accessibility_atspi_bridge=ON
 
 [windows-cl-msvc2022-x86_64]
 General/ABI = windows-cl-msvc2022-x86_64


### PR DESCRIPTION
Partially fixes #860
Do not use qtbase from cache but instead build it from source with a11y and a11y-atspi-bridge features enabled.
> [!IMPORTANT]
> The build system MUST have the necessary libraries installed
> - libatspi2.0-dev
> - libdbus-1-dev

To confirm the features, run the following command:
```bash
strings <path-to>/lib/libQt6Gui.so | grep -i QSpiAccessibleBridge
```