### PR TITLE
test(gui): fix and enable multi-account test scenario

### DIFF
--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -19,21 +19,23 @@ def before_scenario(context, feature):
 
 def after_scenario(context, scenario):
     # clean up sync dir
-    for entry in os.scandir(get_config("clientRootSyncPath")):
-        try:
-            if entry.is_file() or entry.is_symlink():
-                print("Deleting file: " + entry.name)
-                os.unlink(prefix_path_namespace(entry.path))
-            elif entry.is_dir():
-                print("Deleting folder: " + entry.name)
-                shutil.rmtree(prefix_path_namespace(entry.path))
-        except OSError as e:
-            print(f"Failed to delete '{entry.name}'.\nReason: {e}.")
+    if os.path.exists(get_config("clientRootSyncPath")):
+        for entry in os.scandir(get_config("clientRootSyncPath")):
+            try:
+                if entry.is_file() or entry.is_symlink():
+                    print("Deleting file: " + entry.name)
+                    os.unlink(prefix_path_namespace(entry.path))
+                elif entry.is_dir():
+                    print("Deleting folder: " + entry.name)
+                    shutil.rmtree(prefix_path_namespace(entry.path))
+            except OSError as e:
+                print(f"Failed to delete '{entry.name}'.\nReason: {e}.")
     # cleanup paths created outside of the temporary directory during the test
     cleanup_created_paths()
     delete_created_users()
     # quit the application
-    app().quit()
+    if app() is not None:
+        app().quit()
     for process in psutil.process_iter(['pid', 'exe']):
         if process.info['exe'] == get_config("app_path"):
             print("Closing desktop client...")

--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -18,10 +18,6 @@ def before_scenario(context, feature):
 
 
 def after_scenario(context, scenario):
-    # clean up config dir
-    confi_dir = get_config("clientConfigDir")
-    if os.path.exists(confi_dir):
-        shutil.rmtree(confi_dir)
     # clean up sync dir
     for entry in os.scandir(get_config("clientRootSyncPath")):
         try:

--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -19,7 +19,9 @@ def before_scenario(context, feature):
 
 def after_scenario(context, scenario):
     # clean up config dir
-    shutil.rmtree(get_config("clientConfigDir"))
+    confi_dir = get_config("clientConfigDir")
+    if os.path.exists(confi_dir):
+        shutil.rmtree(confi_dir)
     # clean up sync dir
     for entry in os.scandir(get_config("clientRootSyncPath")):
         try:

--- a/test/gui/features/add-account/account.feature
+++ b/test/gui/features/add-account/account.feature
@@ -26,7 +26,7 @@ Feature: adding accounts
             | password | 1234           |
         Then the account with displayname "Alice Hansen" should be displayed
 
-    @smoke @skip
+    @smoke
     Scenario: Adding multiple accounts
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings

--- a/test/gui/helpers/ConfigHelper.py
+++ b/test/gui/helpers/ConfigHelper.py
@@ -1,12 +1,13 @@
 import os
 import platform
 import builtins
+import tempfile
 from tempfile import gettempdir
 from configparser import ConfigParser
 from pathlib import Path
 
 CURRENT_DIR = Path(__file__).resolve().parent
-
+APP_CONFIG_FILE = "opencloud.cfg"
 
 def read_env_file():
     envs = {}
@@ -39,7 +40,7 @@ def is_linux():
 
 
 def get_win_user_home():
-    return os.environ.get('UserProfile')
+    return os.environ.get('USERPROFILE', '')
 
 
 def get_client_root_path():
@@ -48,12 +49,18 @@ def get_client_root_path():
     return os.path.join(gettempdir(), 'opencloudtest')
 
 
+def get_config_home_linux():
+    return os.path.join(tempfile.gettempdir(), 'opencloudtest', '.config')
+
+
+def get_config_home_win():
+    return os.path.join(get_win_user_home(), 'AppData', 'Local', 'Temp', 'opencloudtest', '.config')
+
+
 def get_config_home():
     if is_windows():
-        # There is no way to set custom config path in windows
-        # TODO: set to different path if option is available
-        return os.path.join(get_win_user_home(), 'AppData', 'Roaming', 'OpenCloud')
-    return os.path.join(get_config_from_env_file('XDG_CONFIG_HOME'), 'OpenCloud')
+        return get_config_home_win()
+    return get_config_home_linux()
 
 
 def get_default_home_dir():
@@ -61,6 +68,12 @@ def get_default_home_dir():
         return get_win_user_home()
     return os.environ.get('HOME')
 
+
+def get_app_env():
+    return {
+        'XDG_CONFIG_HOME': get_config_home(),
+        'APPDATA': get_config_home(),
+    }
 
 # map environment variables to config keys
 CONFIG_ENV_MAP = {
@@ -97,8 +110,7 @@ CONFIG = {
     'clientLogDir': '',
     'clientRootSyncPath': get_client_root_path(),
     'tempFolderPath': os.path.join(get_client_root_path(), 'temp'),
-    'clientConfigDir': get_config_home(),
-    'clientConfigFile': os.path.join(get_config_home(), "opencloud.cfg"),
+    'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", "opencloud.cfg"),
     'guiTestReportDir': os.path.abspath('../reports'),
     'record_video_on_failure': False,
     'files_for_upload': os.path.join(CURRENT_DIR.parent.parent, 'files-for-upload'),
@@ -157,7 +169,6 @@ def init_config():
         elif key in (
             'clientRootSyncPath',
             'tempFolderPath',
-            'clientConfigDir',
             'guiTestReportDir',
         ):
             # make sure there is always one trailing slash

--- a/test/gui/helpers/ConfigHelper.py
+++ b/test/gui/helpers/ConfigHelper.py
@@ -110,7 +110,7 @@ CONFIG = {
     'clientLogDir': '',
     'clientRootSyncPath': get_client_root_path(),
     'tempFolderPath': os.path.join(get_client_root_path(), 'temp'),
-    'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", "opencloud.cfg"),
+    'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", APP_CONFIG_FILE),
     'guiTestReportDir': os.path.abspath('../reports'),
     'record_video_on_failure': False,
     'files_for_upload': os.path.join(CURRENT_DIR.parent.parent, 'files-for-upload'),

--- a/test/gui/helpers/SetupClientHelper.py
+++ b/test/gui/helpers/SetupClientHelper.py
@@ -11,10 +11,10 @@ from appium import webdriver
 from appium.options.common.base import AppiumOptions
 
 from helpers.SpaceHelper import get_space_id, get_personal_space_id
-from helpers.ConfigHelper import get_config, set_config, is_windows
+from helpers.ConfigHelper import get_config, set_config, is_windows, get_app_env
 from helpers.SyncHelper import listen_sync_status_for_item
 from helpers.api.utils import url_join
-from helpers.UserHelper import get_displayname_for_user, get_password_for_user
+from helpers.UserHelper import get_displayname_for_user
 from helpers.api import provisioning
 
 
@@ -122,12 +122,7 @@ def start_client():
         'app',
         f'{get_config("app_path")} -s {log_command_suffix} --logdebug',
     )
-    options.set_capability(
-        'appium:environ',
-        {
-            'XDG_CONFIG_HOME': '/tmp/opencloudtest/.config',
-        },
-    )
+    options.set_capability('appium:environ', get_app_env())
     app_driver = webdriver.Remote(
         command_executor='http://127.0.0.1:4723', options=options
     )

--- a/test/gui/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/pageObjects/AccountConnectionWizard.py
@@ -75,11 +75,15 @@ class AccountConnectionWizard:
         AccountConnectionWizard.browser_login(username, password)
 
     @staticmethod
-    def browser_login(username, password):
+    def copy_login_url():
         app().find_element(
             AccountConnectionWizard.COPY_URL_TO_CLIPBOARD_BUTTON.by,
             AccountConnectionWizard.COPY_URL_TO_CLIPBOARD_BUTTON.selector,
         ).click()
+
+    @staticmethod
+    def browser_login(username, password):
+        AccountConnectionWizard.copy_login_url()
         authorize_via_webui(username, password)
 
     @staticmethod

--- a/test/gui/pageObjects/EnterPassword.py
+++ b/test/gui/pageObjects/EnterPassword.py
@@ -1,55 +1,16 @@
-import names
-import squish
+from types import SimpleNamespace
+from appium.webdriver.common.appiumby import AppiumBy as By
 
-
+from pageObjects.AccountConnectionWizard import AccountConnectionWizard
 from helpers.WebUIHelper import authorize_via_webui
-from helpers.ConfigHelper import get_config
+from helpers.SetupClientHelper import app
 
 
 class EnterPassword:
-    LOGIN_CONTAINER = {
-        "name": "LoginRequiredDialog",
-        "type": "OCC::LoginRequiredDialog",
-        "visible": 1,
-    }
-    LOGIN_USER_LABEL = {
-        "container": names.groupBox_OCC_QmlUtils_OCQuickWidget,
-        "type": "Label",
-        "visible": True,
-    }
-    USERNAME_BOX = {
-        "name": "usernameLineEdit",
-        "type": "QLineEdit",
-        "visible": 1,
-        "window": LOGIN_CONTAINER,
-    }
-    LOGOUT_BUTTON = {
-        "container": names.groupBox_OCC_QmlUtils_OCQuickWidget,
-        "id": "logOutButton",
-        "type": "Button",
-        "visible": True,
-    }
-    COPY_URL_TO_CLIPBOARD_BUTTON = {
-        "container": names.groupBox_OCC_QmlUtils_OCQuickWidget,
-        "id": "copyToClipboardButton",
-        "type": "Button",
-        "visible": True,
-    }
-    TLS_CERT_WINDOW = {
-        "name": "OCC__TlsErrorDialog",
-        "type": "OCC::TlsErrorDialog",
-        "visible": 1,
-    }
-    ACCEPT_CERTIFICATE_YES = {
-        "text": "Yes",
-        "type": "QPushButton",
-        "visible": 1,
-        "window": TLS_CERT_WINDOW,
-    }
-
-    def __init__(self, occurrence=1):
-        if occurrence > 1:
-            self.TLS_CERT_WINDOW.update({"occurrence": occurrence})
+    LOGIN_CONTAINER = SimpleNamespace(by=None, selector=None)
+    LOGIN_USER_LABEL = SimpleNamespace(by=None, selector=None)
+    USERNAME_BOX = SimpleNamespace(by=None, selector=None)
+    LOGOUT_BUTTON = SimpleNamespace(by=None, selector=None)
 
     def get_username(self):
         # Parse username from the login label:
@@ -58,9 +19,7 @@ class EnterPassword:
         return username.capitalize()
 
     def oidc_relogin(self, username, password):
-        # wait 500ms for copy button to fully load
-        squish.snooze(1 / 2)
-        squish.mouseClick(squish.waitForObject(self.COPY_URL_TO_CLIPBOARD_BUTTON))
+        AccountConnectionWizard.copy_login_url()
         authorize_via_webui(username, password)
 
     def relogin(self, username, password, oauth=False):
@@ -70,4 +29,4 @@ class EnterPassword:
         self.oidc_relogin(username, password)
 
     def accept_certificate(self):
-        squish.clickButton(squish.waitForObject(self.ACCEPT_CERTIFICATE_YES))
+        AccountConnectionWizard.accept_certificate()

--- a/test/gui/pageObjects/Toolbar.py
+++ b/test/gui/pageObjects/Toolbar.py
@@ -10,7 +10,7 @@ from helpers.SetupClientHelper import app
 class Toolbar:
     TOOLBAR_ROW = SimpleNamespace(by=None, selector=None)
     ACCOUNT_BUTTON = SimpleNamespace(by=None, selector=None)
-    ADD_ACCOUNT_BUTTON = SimpleNamespace(by=None, selector=None)
+    ADD_ACCOUNT_BUTTON = SimpleNamespace(by=By.NAME, selector="Add Account")
     ACTIVITY_BUTTON = SimpleNamespace(by=None, selector=None)
     SETTINGS_BUTTON = SimpleNamespace(by=None, selector=None)
     QUIT_BUTTON = SimpleNamespace(by=None, selector=None)
@@ -41,7 +41,10 @@ class Toolbar:
 
     @staticmethod
     def open_new_account_setup():
-        squish.mouseClick(squish.waitForObject(Toolbar.ADD_ACCOUNT_BUTTON))
+        app().find_element(
+            Toolbar.ADD_ACCOUNT_BUTTON.by,
+            Toolbar.ADD_ACCOUNT_BUTTON.selector,
+        ).click()
 
     @staticmethod
     def open_account(displayname):
@@ -95,8 +98,14 @@ class Toolbar:
 
     @staticmethod
     def get_account(display_name):
-        accounts, selectors = Toolbar.get_accounts()
-        return accounts.get(display_name), selectors.get(display_name)
+        server_host = urlparse(get_config('localBackendUrl')).netloc
+        account_label = f"{display_name}@{server_host}"
+        account = None
+        try:
+            account = app().find_element(By.NAME, account_label)
+        except:
+            pass
+        return account
 
     @staticmethod
     def get_active_account():
@@ -108,11 +117,10 @@ class Toolbar:
 
     @staticmethod
     def account_has_focus(display_name):
-        account, selector = Toolbar.get_account(display_name)
-        return account["current"] and squish.waitForObject(selector).checked
+        account = Toolbar.get_account(display_name)
+        return account.get_attribute("checked") == "true"
 
     @staticmethod
     def account_exists(display_name):
-        server_host = urlparse(get_config('localBackendUrl')).netloc
-        account_label = f"{display_name}@{server_host}"
-        app().find_element(By.NAME, account_label)
+        account = Toolbar.get_account(display_name)
+        return account is not None

--- a/test/gui/requirements.txt
+++ b/test/gui/requirements.txt
@@ -15,4 +15,4 @@ behave==1.3.*; python_version >= "3.10"
 Appium-Python-Client==5.3.*; python_version >= "3.10"
 Flask==3.0.*; python_version >= "3.10" and sys_platform == 'linux'
 numpy==1.26.*; python_version >= "3.10" and sys_platform == 'linux'
-sure=2.0.*; python_version >= "3.10"
+sure==2.0.*; python_version >= "3.10"

--- a/test/gui/requirements.txt
+++ b/test/gui/requirements.txt
@@ -15,3 +15,4 @@ behave==1.3.*; python_version >= "3.10"
 Appium-Python-Client==5.3.*; python_version >= "3.10"
 Flask==3.0.*; python_version >= "3.10" and sys_platform == 'linux'
 numpy==1.26.*; python_version >= "3.10" and sys_platform == 'linux'
+sure=2.0.*; python_version >= "3.10"

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -46,7 +46,7 @@ def step(context, displayname):
     )
 
 
-@Given('user "|any|" has set up a client with default settings')
+@Given('user "{username}" has set up a client with default settings')
 def step(context, username):
     password = get_password_for_user(username)
     setup_client(username)

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -1,17 +1,18 @@
 from behave import given as Given, when as When, then as Then
+from sure import expect
 
 from pageObjects.AccountConnectionWizard import AccountConnectionWizard
-
 from pageObjects.Toolbar import Toolbar
-
+from pageObjects.EnterPassword import EnterPassword
 from helpers.SetupClientHelper import (
     start_client,
+    setup_client,
     substitute_inline_codes,
     get_client_details,
     get_resource_path,
 )
-
 from helpers.SyncHelper import wait_for_initial_sync_to_complete
+from helpers.UserHelper import get_displayname_for_user, get_password_for_user
 
 
 @Given('the user has started the client')
@@ -31,7 +32,7 @@ def step(context):
 @Then('the account with displayname "{displayname}" should be displayed')
 def step(context, displayname):
     displayname = substitute_inline_codes(displayname)
-    Toolbar.account_exists(displayname)
+    expect(Toolbar.account_exists(displayname)).to.be.true
 
 
 @Then('the account with displayname "|any|" should not be displayed')
@@ -241,11 +242,10 @@ def step(context):
     Toolbar.quit_opencloud()
 
 
-@Then('"|any|" account should be opened')
+@Then('"{displayname}" account should be opened')
 def step(context, displayname):
     displayname = substitute_inline_codes(displayname)
-    if not Toolbar.account_has_focus(displayname):
-        raise LookupError(f"Account '{displayname}' should be opened, but it is not")
+    expect(Toolbar.account_has_focus(displayname)).to.be.true
 
 
 @Then(


### PR DESCRIPTION
Part of https://github.com/opencloud-eu/desktop/issues/861

enable following test scenario:
```feature
@smoke
    Scenario: Adding multiple accounts
```
Other changes:
- create app config env helper
- null checks
- added assertion module: [sure](http://sure.readthedocs.io/en/latest/api-reference.html)