### PR TITLE
test(gui): fix and enable manual sync scenario

### DIFF
--- a/test/gui/features/add-account/account.feature
+++ b/test/gui/features/add-account/account.feature
@@ -50,7 +50,7 @@ Feature: adding accounts
             | password | 1234  |
         Then "Alice Hansen" account should be opened
 
-    @smoke @skip
+    @smoke
     Scenario: Add space manually from sync connection window
         Given user "Alice" has created folder "simple-folder" in the server
         And the user has started the client

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
+from selenium.webdriver.common.keys import Keys
 import time
 
 from helpers.SetupClientHelper import get_current_user_sync_path
@@ -136,7 +137,11 @@ class SyncConnectionWizard:
                 space_name=space_name
             ),
         )
-        space_item.click()
+        # ISSUE: https://github.com/opencloud-eu/desktop/pull/879
+        # Workaround until above fix is merged
+        # TODO: Remove 'send_keys' and uncomment 'click' action
+        space_item.send_keys(Keys.ARROW_DOWN)
+        # space_item.click()
         if space_item.get_attribute("selected") != "true":
             raise AssertionError("Failed to select the space: " + space_name)
 


### PR DESCRIPTION
I have added a workaround to fix the space selection from the list until https://github.com/opencloud-eu/desktop/pull/879 is merged

`el.send_keys(Keys.ARROW_DOWN)` selects the FIRST space in the list. Therefore, this cannot be the permanent fix.