### PR TITLE
test(gui): enable more syncing tests in appium

### DIFF
--- a/test/gui/features/sync-resources/syncResources.feature
+++ b/test/gui/features/sync-resources/syncResources.feature
@@ -327,7 +327,7 @@ Feature: Syncing files
         But the folder "CON" should not exist on the file system
         And the file "PRN" should not exist on the file system
 
-    @smoke @skip
+    @smoke
     Scenario: various types of files can be synced from server to client
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file "testavatar.png" to "simple-folder/testavatar.png" in the server
@@ -428,7 +428,7 @@ Feature: Syncing files
         And as "Alice" folder "folder3" should exist in the server
         And as user "Alice" folder "folder3" should contain "1000" items in the server
 
-    @smoke @skip
+    @smoke
     Scenario: Skip sync folder configuration
         Given the user has started the client
         And the user has entered the following account information:

--- a/test/gui/features/sync-resources/syncResources.feature
+++ b/test/gui/features/sync-resources/syncResources.feature
@@ -6,7 +6,7 @@ Feature: Syncing files
     Background:
         Given user "Alice" has been created in the server with default attributes
 
-    @issue-9281 @smoke @skip
+    @issue-9281 @smoke
     Scenario: Syncing a file to the server
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "lorem-for-upload.txt" with the following content inside the sync folder
@@ -19,7 +19,7 @@ Feature: Syncing files
         Then the file "lorem-for-upload.txt" should have status "Uploaded" in the activity tab
         And as "Alice" the file "lorem-for-upload.txt" should have the content "test content" in the server
 
-    @smoke @skip
+    @smoke
     Scenario: Syncing all files and folders from the server
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created folder "large-folder" in the server
@@ -235,7 +235,7 @@ Feature: Syncing files
         And as "Alice" folder "parent/subfolder4" should exist in the server
         And as "Alice" folder "parent/subfolder5" should exist in the server
 
-    @smoke @skip
+    @smoke
     Scenario: Both original and copied folders can be synced
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "original" inside the sync folder
@@ -299,7 +299,7 @@ Feature: Syncing files
             | foldername                                                      |
             | An empty folder which name is obviously more than 59 characters |
 
-    @skipOnWindows @smoke @skip
+    @skipOnWindows @smoke
     Scenario: Invalid system names are synced (Linux only)
         Given user "Alice" has created folder "CON" in the server
         And user "Alice" has created folder "test%" in the server

--- a/test/gui/helpers/ConfigHelper.py
+++ b/test/gui/helpers/ConfigHelper.py
@@ -113,7 +113,7 @@ CONFIG = {
     'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", APP_CONFIG_FILE),
     'guiTestReportDir': os.path.abspath('../reports'),
     'record_video_on_failure': False,
-    'files_for_upload': os.path.join(CURRENT_DIR.parent.parent, 'files-for-upload'),
+    'files_for_upload': os.path.join(CURRENT_DIR.parent, 'files-for-upload'),
     'syncConnectionName': 'Personal',
 }
 

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -18,6 +18,7 @@ class Activity:
     NOT_SYNCED_FILTER_OPTION_SELECTOR = SimpleNamespace(by=None, selector=None)
     SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     NOT_SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
+    SYNCED_ACTIVITY_STATUS = SimpleNamespace(by=By.NAME, selector=None)
 
 
     @staticmethod
@@ -83,13 +84,11 @@ class Activity:
     @staticmethod
     def has_sync_status(filename, status):
         try:
-            file_row = squish.waitForObject(
-                Activity.get_not_synced_file_selector(filename),
-                get_config("lowestSyncTimeout") * 1000,
-                )["row"]
-            if Activity.get_not_synced_status(file_row) == status:
-                return True
-            return False
+            app().find_element(
+                Activity.SYNCED_ACTIVITY_STATUS.by,
+                status
+            )
+            return True
         except:
             return False
 

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -20,7 +20,7 @@ class SyncConnectionWizard:
     )
     REMOTE_FOLDER_TREE = SimpleNamespace(by=None, selector=None)
     SELECTIVE_SYNC_TREE_HEADER = SimpleNamespace(by=None, selector=None)
-    CANCEL_FOLDER_SYNC_CONNECTION_WIZARD = SimpleNamespace(by=None, selector=None)
+    CANCEL_FOLDER_SYNC_CONNECTION_WIZARD = SimpleNamespace(by=By.NAME, selector="Cancel")
     SPACES_LIST = SimpleNamespace(by=By.NAME, selector="Spaces list")
     SPACE_NAME_SELECTOR = SimpleNamespace(by=By.NAME, selector="{space_name},")
     CREATE_REMOTE_FOLDER_BUTTON = SimpleNamespace(by=None, selector=None)
@@ -119,11 +119,10 @@ class SyncConnectionWizard:
 
     @staticmethod
     def cancel_folder_sync_connection_wizard():
-        squish.clickButton(
-            squish.waitForObject(
-                SyncConnectionWizard.CANCEL_FOLDER_SYNC_CONNECTION_WIZARD
-            )
-        )
+        app().find_element(
+            SyncConnectionWizard.CANCEL_FOLDER_SYNC_CONNECTION_WIZARD.by,
+            SyncConnectionWizard.CANCEL_FOLDER_SYNC_CONNECTION_WIZARD.selector,
+        ).click()
 
     @staticmethod
     def select_space(space_name):

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -4,6 +4,7 @@ from behave import given as Given, when as When, then as Then
 from sure import expect
 
 from pageObjects.AccountConnectionWizard import AccountConnectionWizard
+from pageObjects.SyncConnectionWizard import SyncConnectionWizard
 from pageObjects.AccountSetting import AccountSetting
 from pageObjects.Toolbar import Toolbar
 from pageObjects.EnterPassword import EnterPassword

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -175,7 +175,7 @@ def step(context, resource_type, resource_name, destination_dir):
     copy_resource(resource_type, resource_name, destination_dir, False)
 
 
-@When(r'the user copies (file|folder) "([^"]*)" into the same directory', regexp=True)
+@When('the user copies {resource_type:ResourceType} "{resource_name}" into the same directory')
 def step(context, resource_type, resource_name):
     copy_resource(resource_type, resource_name, resource_name, False)
 
@@ -187,19 +187,19 @@ def step(context, source, destination):
     rename_file_folder(source, destination)
 
 
-@Then('the file "|any|" should exist on the file system with the following content')
+@Then('the file "{file_path}" should exist on the file system with the following content')
 def step(context, file_path):
-    expected = '\n'.join(context.multiLineText)
+    expected = context.text
     file_path = get_resource_path(file_path)
     with open(file_path, 'r', encoding='utf-8') as f:
         contents = f.read()
-    test.compare(
-        expected,
-        contents,
-        'file expected to exist with content '
-        + expected
-        + ' but does not have the expected content',
-    )
+    with ensure(
+            '{0} expected to exist with content "{1}" but exists with content "{2}"',
+            file_path,
+            expected,
+            contents,
+    ):
+        contents.should.equal(expected)
 
 
 @Then('the {resource_type:ResourceType} "{resource}" should exist on the file system')

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -194,7 +194,7 @@ def step(context, file_path):
     with open(file_path, 'r', encoding='utf-8') as f:
         contents = f.read()
     with ensure(
-            '{0} expected to exist with content "{1}" but exists with content "{2}"',
+            '{0} expected to exist with content "{1}" but has content "{2}"',
             file_path,
             expected,
             contents,

--- a/test/gui/steps/server_context.py
+++ b/test/gui/steps/server_context.py
@@ -90,7 +90,7 @@ def step(context, user, folder_name):
     webdav.delete_resource(user, folder_name)
 
 
-@Given('user "|any|" has uploaded file "|any|" to "|any|" in the server')
+@Given('user "{user}" has uploaded file "{file_name}" to "{destination}" in the server')
 def step(context, user, file_name, destination):
     webdav.upload_file(user, file_name, destination)
 

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -237,7 +237,7 @@ def step(context):
     SyncConnection.confirm_folder_sync_connection_removal()
 
 
-@Then('the file "|any|" should have status "|any|" in the activity tab')
+@Then('the file "{file_name}" should have status "{status}" in the activity tab')
 def step(context, file_name, status):
     Activity.has_sync_status(file_name, status)
 


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861


Enabled following scenarios:

```feature
Scenario: Syncing a file to the server
Scenario: Syncing all files and folders from the server
Scenario: Both original and copied folders can be synced
Scenario: Invalid system names are synced (Linux only)
Scenario: various types of files can be synced from server to client
Scenario: Skip sync folder configuration
```