### PR TITLE
test(gui): enable syncing tests

### DIFF
--- a/test/gui/features/sync-resources/syncResources.feature
+++ b/test/gui/features/sync-resources/syncResources.feature
@@ -82,7 +82,7 @@ Feature: Syncing files
         But the folder "simple-folder" should not exist on the file system
         And the folder "large-folder" should not exist on the file system
 
-    @skipOnWindows @smoke @skip
+    @skipOnWindows @smoke
     Scenario: Sync only one folder from the server
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created folder "large-folder" in the server

--- a/test/gui/features/sync-resources/syncResources.feature
+++ b/test/gui/features/sync-resources/syncResources.feature
@@ -571,7 +571,7 @@ Feature: Syncing files
         And as "Brian" file "Shares/simple-folder/simple.pdf" should exist in the server
         And as "Brian" the file "Shares/simple-folder/uploaded-lorem.txt" should have the content "overwrite openCloud test text file" in the server
 
-    @skipOnWindows @smoke @skip
+    @skipOnWindows @smoke
     Scenario: Unselected subfolders are excluded from local sync
         Given user "Alice" has created folder "test-folder" in the server
         And user "Alice" has created folder "test-folder/sub-folder1" in the server
@@ -580,6 +580,7 @@ Feature: Syncing files
         When the user unselects the following folders to sync in "Choose what to sync" window:
             | folder                  |
             | test-folder/sub-folder2 |
+        And the user waits for the files to sync
         Then the folder "test-folder/sub-folder1" should exist on the file system
         But the folder "test-folder/sub-folder2" should not exist on the file system
         When user "Alice" uploads file with content "some content" to "test-folder/sub-folder2/lorem.txt" in the server

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -1,3 +1,4 @@
+from selenium.webdriver.common import keys
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
@@ -5,6 +6,7 @@ import time
 
 from helpers.SetupClientHelper import get_current_user_sync_path
 from helpers.SetupClientHelper import app
+from selenium.webdriver.common.action_chains import ActionChains
 
 
 class SyncConnectionWizard:
@@ -71,15 +73,21 @@ class SyncConnectionWizard:
 
     @staticmethod
     def deselect_all_remote_folders():
+        another = app().find_element(
+            By.NAME,
+            "Add Space"
+        )
+        another.send_keys(Keys.ARROW_DOWN)
+        another.send_keys(" ")
         # NOTE: checkbox does not have separate object
         # click on (11,11) which is a checkbox
-        squish.mouseClick(
-            squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER),
-            11,
-            11,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
+        # squish.mouseClick(
+        #     squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER),
+        #     11,
+        #     11,
+        #     squish.Qt.NoModifier,
+        #     squish.Qt.LeftButton,
+        # )
 
     @staticmethod
     def sort_by(header_text):
@@ -201,44 +209,36 @@ class SyncConnectionWizard:
 
     @staticmethod
     def select_or_unselect_folders_to_sync(
-        folders, should_select=True, new_sync_connection_wizard=False
+            folders,
+            should_select=True,
+            new_sync_connection_wizard=False,
     ):
         if should_select:
-            # First deselect all
             SyncConnectionWizard.deselect_all_remote_folders()
-        folder_tree_locator = SyncConnectionWizard.get_folder_tree_locator(
-            new_sync_connection_wizard
-        )
+
         for folder in folders:
-            folder_levels = folder.strip("/").split("/")
-            parent_selector = None
-            for sub_folder in folder_levels:
-                if not parent_selector:
-                    folder_tree_locator["text"] = sub_folder
-                    parent_selector = folder_tree_locator
-                    selector = parent_selector
-                else:
-                    selector = {
-                        "column": "0",
-                        "container": parent_selector,
-                        "text": sub_folder,
-                        "type": "QModelIndex",
-                    }
-                if (
-                    len(folder_levels) == 1
-                    or folder_levels.index(sub_folder) == len(folder_levels) - 1
-                ):
-                    # NOTE: checkbox does not have separate object
-                    # click on (11,11) which is a checkbox
-                    squish.mouseClick(
-                        squish.waitForObject(selector),
-                        11,
-                        11,
-                        squish.Qt.NoModifier,
-                        squish.Qt.LeftButton,
-                    )
-                else:
-                    squish.doubleClick(squish.waitForObject(selector))
+            # breakpoint()
+            folder_name = folder.strip("/").split("/")[-1]
+            # print(folder_name)
+            # import time
+            # time.sleep(5)
+            # breakpoint()
+
+            folder_element = app().find_element(
+                By.XPATH,
+                f"//tree//*[@name='{folder_name}']"
+            )
+            print(folder_element)
+
+            folder_element.click()
+            # tree = app().find_element(By.XPATH, "//tree")
+            # folder_element.send_keys(Keys.ARROW_DOWN)
+            # tree.send_keys(Keys.ARROW_DOWN)
+            # tree.send_keys(Keys.TAB)
+            folder_element.send_keys(Keys.ENTER)
+            time.sleep(10)
+
+
 
     @staticmethod
     def confirm_choose_what_to_sync_selection():

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -1,12 +1,11 @@
-from selenium.webdriver.common import keys
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
 import time
+import pyautogui
 
 from helpers.SetupClientHelper import get_current_user_sync_path
 from helpers.SetupClientHelper import app
-from selenium.webdriver.common.action_chains import ActionChains
 
 
 class SyncConnectionWizard:
@@ -16,7 +15,6 @@ class SyncConnectionWizard:
     BACK_BUTTON = SimpleNamespace(by=By.NAME, selector="< Back")
     NEXT_BUTTON = SimpleNamespace(by=By.NAME, selector="Next >")
     SELECTIVE_SYNC_ROOT_FOLDER = SimpleNamespace(by=None, selector=None)
-    ADD_SPACE_FOLDER_TREE = SimpleNamespace(by=None, selector=None)
     ADD_SYNC_CONNECTION_BUTTON = SimpleNamespace(
         by=By.XPATH, selector="//dialog[@name='Add Space']//*[@name='Add Space']"
     )
@@ -73,21 +71,12 @@ class SyncConnectionWizard:
 
     @staticmethod
     def deselect_all_remote_folders():
-        another = app().find_element(
+        element = app().find_element(
             By.NAME,
             "Add Space"
         )
-        another.send_keys(Keys.ARROW_DOWN)
-        another.send_keys(" ")
-        # NOTE: checkbox does not have separate object
-        # click on (11,11) which is a checkbox
-        # squish.mouseClick(
-        #     squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER),
-        #     11,
-        #     11,
-        #     squish.Qt.NoModifier,
-        #     squish.Qt.LeftButton,
-        # )
+        element.send_keys(Keys.ARROW_DOWN)
+        element.send_keys(" ")
 
     @staticmethod
     def sort_by(header_text):
@@ -210,46 +199,45 @@ class SyncConnectionWizard:
     @staticmethod
     def select_or_unselect_folders_to_sync(
             folders,
-            should_select=True,
-            new_sync_connection_wizard=False,
+            should_select=True
     ):
         if should_select:
             SyncConnectionWizard.deselect_all_remote_folders()
 
         for folder in folders:
-            # breakpoint()
-            folder_name = folder.strip("/").split("/")[-1]
-            # print(folder_name)
-            # import time
-            # time.sleep(5)
-            # breakpoint()
+            path_parts = folder.strip("/").split("/")
 
-            folder_element = app().find_element(
-                By.XPATH,
-                f"//tree//*[@name='{folder_name}']"
-            )
-            print(folder_element)
+            for i in range(len(path_parts) - 1):
+                parent_folder_name = path_parts[i]
+                parent_elements = app().find_elements(By.NAME, parent_folder_name)
 
-            folder_element.click()
-            # tree = app().find_element(By.XPATH, "//tree")
-            # folder_element.send_keys(Keys.ARROW_DOWN)
-            # tree.send_keys(Keys.ARROW_DOWN)
-            # tree.send_keys(Keys.TAB)
-            folder_element.send_keys(Keys.ENTER)
-            time.sleep(10)
+                for element in parent_elements:
+                    isChecked = element.get_attribute("checked")
+                    if isChecked == "true":
+                        parent_bounds = element.rect
+                        center_x = int(parent_bounds['x'] + parent_bounds['width'] // 2)
+                        center_y = int(parent_bounds['y'] + parent_bounds['height'] // 2)
+                        pyautogui.doubleClick(center_x, center_y)
 
+            target_folder_name = path_parts[-1]
+            folder_element = app().find_element(By.NAME, target_folder_name)
 
+            element_bounds = folder_element.rect
+            checkbox_x_position = int(element_bounds['x'] + 10)
+            checkbox_y_position = int(element_bounds['y'] + element_bounds['height'] // 2)
+
+            pyautogui.moveTo(checkbox_x_position, checkbox_y_position, duration=0.1)
+            pyautogui.click()
 
     @staticmethod
     def confirm_choose_what_to_sync_selection():
-        squish.clickButton(squish.waitForObject(names.stackedWidget_OK_QPushButton))
+        app().find_element(By.NAME, "OK").click()
 
     @staticmethod
     def __handle_folder_selection(folders, should_select, new_sync_connection_wizard):
         SyncConnectionWizard.select_or_unselect_folders_to_sync(
             folders,
-            should_select=should_select,
-            new_sync_connection_wizard=new_sync_connection_wizard,
+            should_select=should_select
         )
 
         if new_sync_connection_wizard:
@@ -271,12 +259,4 @@ class SyncConnectionWizard:
             folders,
             should_select=True,
             new_sync_connection_wizard=new_sync_connection_wizard,
-        )
-
-    @staticmethod
-    def get_folder_tree_locator(new_sync_connection_wizard=False):
-        return (
-            SyncConnectionWizard.ADD_SPACE_FOLDER_TREE.copy()
-            if new_sync_connection_wizard
-            else SyncConnectionWizard.CHOOSE_WHAT_TO_SYNC_FOLDER_TREE.copy()
         )

--- a/test/gui/requirements.txt
+++ b/test/gui/requirements.txt
@@ -16,3 +16,4 @@ Appium-Python-Client==5.3.*; python_version >= "3.10"
 Flask==3.0.*; python_version >= "3.10" and sys_platform == 'linux'
 numpy==1.26.*; python_version >= "3.10" and sys_platform == 'linux'
 sure==2.0.*; python_version >= "3.10"
+pyautogui==0.9.*; python_version >= "3.10"

--- a/test/gui/steps/server_context.py
+++ b/test/gui/steps/server_context.py
@@ -80,7 +80,7 @@ def step(context):
     Toolbar.open_settings_tab()
 
 
-@When('user "|any|" uploads file with content "|any|" to "|any|" in the server')
+@When('user "{user}" uploads file with content "{file_content}" to "{file_name}" in the server')
 def step(context, user, file_content, file_name):
     webdav.create_file(user, file_name, file_content)
 

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -117,7 +117,7 @@ def step(context):
 @When('the user selects the following folders to sync:')
 def step(context):
     folders = []
-    for row in context.table[1:]:
+    for row in context.table:
         folders.append(row[0])
     SyncConnectionWizard.select_folders_to_sync(
         folders, new_sync_connection_wizard=True
@@ -152,7 +152,7 @@ def step(context):
         row_index += 1
 
 
-@When('the user selects "|any|" space in sync connection wizard')
+@When('the user selects "{space_name}" space in sync connection wizard')
 def step(context, space_name):
     SyncConnectionWizard.select_space(space_name)
     SyncConnectionWizard.next_step()
@@ -320,7 +320,7 @@ def step(context, wait_for):
 def step(context):
     SyncConnection.choose_what_to_sync()
     folders = []
-    for row in context.table[1:]:
+    for row in context.table:
         folders.append(row[0])
     SyncConnectionWizard.unselect_folders_to_sync(
         folders, new_sync_connection_wizard=False


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861

Enabled the following syncing tests:

```feature
Scenario: Sync only one folder from the server
```

```feature
Scenario: Unselected subfolders are excluded from local sync
```


Added a new Python library called [PyAutoGui](https://pyautogui.readthedocs.io/en/latest/index.html) for GUI automation(mouse, keyboard, screenshots, etc.)