### PR TITLE
ci: run GUI test suites parallelly using a matrix

### DIFF
--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -35,10 +35,10 @@ workspace:
 
 matrix:
   include:
-    - SUITES: 'features/activity features/add-account features/delete-files-folders features/edit-files features/login-logout features/move-files-folders'
-      MATRIX_NAME: gui-tests-1
-    - SUITES: 'features/remove-account-connection features/spaces features/sync-resources features/tabs-settings features/vfs'
-      MATRIX_NAME: gui-tests-2
+    - MATRIX_NAME: gui-tests-1
+      SUITES: 'features/activity features/add-account features/delete-files-folders features/edit-files features/login-logout features/move-files-folders'
+    - MATRIX_NAME: gui-tests-2
+      SUITES: 'features/remove-account-connection features/spaces features/sync-resources features/tabs-settings features/vfs'
 
 steps:
   - name: restore-python-cache
@@ -147,7 +147,7 @@ steps:
       <<: *minio_environment
     commands:
       - mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
-      - mc cp -a -r $CI_WORKSPACE/test/gui/reports s3/$PUBLIC_BUCKET/desktop/testlogs/$CI_PIPELINE_NUMBER
+      - mc cp -a -r $CI_WORKSPACE/test/gui/reports s3/$PUBLIC_BUCKET/desktop/testlogs/$CI_PIPELINE_NUMBER/$MATRIX_NAME
 
   - name: gui-test-reports
     image: *minio_image

--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -33,6 +33,13 @@ workspace:
   base: /woodpecker
   path: desktop
 
+matrix:
+  include:
+    - SUITES: 'features/activity features/add-account features/delete-files-folders features/edit-files features/login-logout features/move-files-folders'
+      MATRIX_NAME: gui-tests-1
+    - SUITES: 'features/remove-account-connection features/spaces features/sync-resources features/tabs-settings features/vfs'
+      MATRIX_NAME: gui-tests-2
+
 steps:
   - name: restore-python-cache
     image: *minio_image
@@ -121,7 +128,7 @@ steps:
       GUI_TEST_REPORT_DIR: /woodpecker/desktop/test/gui/reports
       BEHAVE_TEST_DIR: /woodpecker/desktop/test/gui
       # Cannot handle this tags format inside a container: --tags='@smoke and not @skip'
-      BEHAVE_PARAMETERS: '--tags=@smoke --tags=~@skip features'
+      BEHAVE_PARAMETERS: '--tags=@smoke --tags=~@skip ${SUITES}'
 
   # - name: crash-log
   #   image: *alpine_image

--- a/test/gui/woodpecker/gui_test_reports.sh
+++ b/test/gui/woodpecker/gui_test_reports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPORT_PATH="$PUBLIC_BUCKET/desktop/testlogs/$CI_PIPELINE_NUMBER/reports"
+REPORT_PATH="$PUBLIC_BUCKET/desktop/testlogs/$CI_PIPELINE_NUMBER/$MATRIX_NAME/reports"
 REPORT_URL="$MC_HOST/$REPORT_PATH"
 
 echo ""


### PR DESCRIPTION
Split GUI test suites and run them parallelly.
The following matrix is added:
```yaml
matrix:
  include:
    - SUITES: 'features/activity features/add-account features/delete-files-folders features/edit-files features/login-logout features/move-files-folders'
      MATRIX_NAME: gui-tests-1
    - SUITES: 'features/remove-account-connection features/spaces features/sync-resources features/tabs-settings features/vfs'
      MATRIX_NAME: gui-tests-2
``` 

Example:
<img width="448" height="268" alt="Screenshot from 2026-05-11 15-03-07" src="https://github.com/user-attachments/assets/a120c3c0-5a69-4352-ba05-2b007fe17b87" />
