### PR TITLE
test(gui): implement screenshot reports

### DIFF
--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -1,6 +1,9 @@
 import shutil
 import os
+import re
+import pyautogui
 from behave.model_core import Status
+from datetime import datetime
 
 from helpers.ConfigHelper import init_config
 from helpers.api.provisioning import delete_created_users
@@ -38,6 +41,18 @@ def cleanup_app_log():
 
 def before_feature(context, feature):
     init_config()
+
+
+def after_step(context, step):
+    if step.status in [Status.failed, Status.error]:
+
+        step_name = re.sub(r'[^a-zA-Z0-9_]', '_', step.name)
+        timestamp = datetime.now().strftime("%d-%b-%Y_%H-%M-%S")
+        screenshots_dir = os.path.join(get_config("guiTestReportDir"), "screenshots")
+        os.makedirs(screenshots_dir, exist_ok=True)
+
+        file_path = os.path.join(screenshots_dir, f"{step_name}_{timestamp}.png")
+        pyautogui.screenshot(file_path)
 
 
 def after_scenario(context, scenario):


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861

Implemented automatic screenshot capture for `failed/error` steps using `pyautogui`
    - Added after_step() hook to capture screenshots on step failures
    - Screenshots are stored under `reports/screenshots/`