### PR TITLE
refactor(gui-test): bind pyautogui methods to appium element

### DIFF
--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -10,7 +10,7 @@ from helpers.api.provisioning import delete_created_users
 from helpers.SpaceHelper import delete_project_spaces
 from helpers.ConfigHelper import get_config
 from helpers.FilesHelper import prefix_path_namespace, cleanup_created_paths
-from helpers.SetupClientHelper import close_and_kill_app
+from helpers.AppHelper import close_and_kill_app
 from step_types.types import *  # register all step types
 
 

--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -1,0 +1,71 @@
+import pyautogui
+import psutil
+from appium.webdriver import Remote, WebElement
+from appium.options.common.base import AppiumOptions
+
+from helpers.ConfigHelper import get_config, get_app_env
+from helpers.ElementHelper import get_element_center_xy
+from helpers.keys.keys_map import get_key
+
+
+def native_click(self):
+    x, y = get_element_center_xy(self)
+    pyautogui.click(x, y)
+
+
+def native_double_click(self):
+    x, y = get_element_center_xy(self)
+    pyautogui.doubleClick(x, y)
+
+
+def native_send_keys(self, key):
+    pyautogui.press(get_key(key))
+
+
+# bind custom element methods
+WebElement.native_click = native_click
+WebElement.native_double_click = native_double_click
+WebElement.native_send_keys = native_send_keys
+
+app_driver = None
+
+
+def app():
+    return app_driver
+
+
+def create_app_session():
+    global app_driver
+    logfile = get_config("currentAppLogFile")
+    command_args = f' --logfile {logfile}'
+
+    options = AppiumOptions()
+    options.set_capability(
+        'app',
+        f'{get_config("app_path")} -s {command_args} --logdebug',
+    )
+    options.set_capability('appium:environ', get_app_env())
+    app_driver = Remote(command_executor='http://localhost:4723', options=options)
+    app_driver.implicitly_wait = 10
+
+
+def close_and_kill_app():
+    """
+    Close Appium session and kill the desktop client process.
+    Use this for both mid-scenario and end-of-scenario cleanup.
+    """
+    global app_driver
+    # Quit Appium session
+    if app_driver is not None:
+        app_driver.quit()
+
+    # Kill remaining process by exe path
+    app_path = get_config("app_path")
+    for process in psutil.process_iter(['pid', 'exe']):
+        if process.info['exe'] == app_path:
+            print("Closing desktop client...")
+            psutil.Process(process.info['pid']).kill()
+            break
+
+    # Reset driver for reuse
+    app_driver = None

--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -8,14 +8,14 @@ from helpers.ElementHelper import get_element_center_xy
 from helpers.keys.keys_map import get_key
 
 
-def native_click(self):
+def native_click(self, **kwargs):
     x, y = get_element_center_xy(self)
-    pyautogui.click(x, y)
+    pyautogui.click(x, y, **kwargs)
 
 
-def native_double_click(self):
+def native_double_click(self, **kwargs):
     x, y = get_element_center_xy(self)
-    pyautogui.doubleClick(x, y)
+    pyautogui.doubleClick(x, y, **kwargs)
 
 
 def native_send_keys(self, key):

--- a/test/gui/helpers/ElementHelper.py
+++ b/test/gui/helpers/ElementHelper.py
@@ -1,0 +1,5 @@
+def get_element_center_xy(element):
+    rect = element.rect
+    x = int(rect['x'] + (rect['width'] // 2))
+    y = int(rect['y'] + (rect['height'] // 2))
+    return x, y

--- a/test/gui/helpers/SetupClientHelper.py
+++ b/test/gui/helpers/SetupClientHelper.py
@@ -2,26 +2,18 @@
 import os
 import subprocess
 import test
-import psutil
 from urllib.parse import urlparse
 from os import makedirs
 from os.path import exists, join
 from PySide6.QtCore import QSettings, QUuid, QUrl, QJsonValue
-from appium import webdriver
-from appium.options.common.base import AppiumOptions
 
 from helpers.SpaceHelper import get_space_id, get_personal_space_id
-from helpers.ConfigHelper import get_config, set_config, is_windows, get_app_env
+from helpers.ConfigHelper import get_config, set_config, is_windows
 from helpers.SyncHelper import listen_sync_status_for_item
 from helpers.api.utils import url_join
 from helpers.UserHelper import get_displayname_for_user
 from helpers.api import provisioning
-
-app_driver = None
-
-
-def app():
-    return app_driver
+from helpers.AppHelper import create_app_session
 
 
 def substitute_inline_codes(value):
@@ -106,20 +98,7 @@ def get_current_user_sync_path():
 
 
 def start_client():
-    global app_driver
-    logfile = get_config("currentAppLogFile")
-    command_args = f' --logfile {logfile}'
-
-    options = AppiumOptions()
-    options.set_capability(
-        'app',
-        f'{get_config("app_path")} -s {command_args} --logdebug',
-    )
-    options.set_capability('appium:environ', get_app_env())
-    app_driver = webdriver.Remote(
-        command_executor='http://localhost:4723', options=options
-    )
-    app_driver.implicitly_wait = 10
+    create_app_session()
 
 
 def get_polling_interval():
@@ -198,24 +177,6 @@ def setup_client(username, space='Personal'):
         listen_sync_status_for_item(sync_path)
 
 
-def is_app_killed(pid):
-    try:
-        psutil.Process(pid)
-        return False
-    except psutil.NoSuchProcess:
-        return True
-
-
-def wait_until_app_killed(pid=0):
-    timeout = 5 * 1000
-    killed = squish.waitFor(
-        lambda: is_app_killed(pid),
-        timeout,
-    )
-    if not killed:
-        test.log(f'Application was not terminated within {timeout} milliseconds')
-
-
 def generate_uuidv4():
     return str(uuid.uuid4())
 
@@ -264,25 +225,3 @@ def run_sys_command(command=None, shell=False):
         check=False,
     )
     return cmd.stdout, cmd.stderr, cmd.returncode
-
-
-def close_and_kill_app():
-    """
-    Close Appium session and kill the desktop client process.
-    Use this for both mid-scenario and end-of-scenario cleanup.
-    """
-    global app_driver
-    # Quit Appium session
-    if app_driver is not None:
-        app_driver.quit()
-
-    # Kill remaining process by exe path
-    app_path = get_config("app_path")
-    for process in psutil.process_iter(['pid', 'exe']):
-        if process.info['exe'] == app_path:
-            print("Closing desktop client...")
-            psutil.Process(process.info['pid']).kill()
-            break
-
-    # Reset driver for reuse
-    app_driver = None

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -369,7 +369,7 @@ def make_available_locally(resource_path):
 
 
 def wait_for(condition, timeout, interval=0.5):
-    from helpers.SetupClientHelper import app
+    from helpers.AppHelper import app
 
     wait = WebDriverWait(app(), timeout / 1000, poll_frequency=interval)
     try:

--- a/test/gui/helpers/keys/keys_map.py
+++ b/test/gui/helpers/keys/keys_map.py
@@ -1,0 +1,76 @@
+from selenium.webdriver.common.keys import Keys
+
+# Key mapping from Selenium's Keys to pyautogui's key names
+# See:
+#  - https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.common.keys
+#  - https://pyautogui.readthedocs.io/en/latest/keyboard.html?highlight=keys#keyboard-keys
+KEY_MAP = {
+    Keys.ADD: 'add',
+    Keys.ALT: 'alt',
+    Keys.ARROW_DOWN: 'down',
+    Keys.ARROW_LEFT: 'left',
+    Keys.ARROW_RIGHT: 'right',
+    Keys.ARROW_UP: 'up',
+    Keys.BACKSPACE: 'backspace',
+    Keys.BACK_SPACE: 'backspace',
+    Keys.CLEAR: 'clear',
+    Keys.COMMAND: 'command',
+    Keys.CONTROL: 'ctrl',
+    Keys.DECIMAL: 'decimal',
+    Keys.DELETE: 'delete',
+    Keys.DIVIDE: 'divide',
+    Keys.DOWN: 'down',
+    Keys.END: 'end',
+    Keys.ENTER: 'enter',
+    Keys.EQUALS: '=',
+    Keys.ESCAPE: 'escape',
+    Keys.F1: 'f1',
+    Keys.F10: 'f10',
+    Keys.F11: 'f11',
+    Keys.F12: 'f12',
+    Keys.F2: 'f2',
+    Keys.F3: 'f3',
+    Keys.F4: 'f4',
+    Keys.F5: 'f5',
+    Keys.F6: 'f6',
+    Keys.F7: 'f7',
+    Keys.F8: 'f8',
+    Keys.F9: 'f9',
+    Keys.HELP: 'help',
+    Keys.HOME: 'home',
+    Keys.INSERT: 'insert',
+    Keys.LEFT: 'left',
+    Keys.LEFT_ALT: 'altleft',
+    Keys.LEFT_CONTROL: 'ctrlleft',
+    Keys.LEFT_SHIFT: 'shiftleft',
+    Keys.META: 'win',
+    Keys.MULTIPLY: 'multiply',
+    Keys.NUMPAD0: 'num0',
+    Keys.NUMPAD1: 'num1',
+    Keys.NUMPAD2: 'num2',
+    Keys.NUMPAD3: 'num3',
+    Keys.NUMPAD4: 'num4',
+    Keys.NUMPAD5: 'num5',
+    Keys.NUMPAD6: 'num6',
+    Keys.NUMPAD7: 'num7',
+    Keys.NUMPAD8: 'num8',
+    Keys.NUMPAD9: 'num9',
+    Keys.PAGE_DOWN: 'pagedown',
+    Keys.PAGE_UP: 'pageup',
+    Keys.PAUSE: 'pause',
+    Keys.RETURN: 'return',
+    Keys.RIGHT: 'right',
+    Keys.SEMICOLON: ';',
+    Keys.SEPARATOR: 'separator',
+    Keys.SHIFT: 'shift',
+    Keys.SPACE: 'space',
+    Keys.SUBTRACT: 'subtract',
+    Keys.TAB: 'tab',
+    Keys.UP: 'up',
+}
+
+
+def get_key(key):
+    if key in KEY_MAP:
+        return KEY_MAP[key]
+    return key

--- a/test/gui/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/pageObjects/AccountConnectionWizard.py
@@ -10,7 +10,7 @@ from helpers.SetupClientHelper import (
     set_current_user_sync_path,
 )
 from helpers.SyncHelper import listen_sync_status_for_item
-from helpers.SetupClientHelper import app
+from helpers.AppHelper import app
 
 
 class AccountConnectionWizard:

--- a/test/gui/pageObjects/AccountSetting.py
+++ b/test/gui/pageObjects/AccountSetting.py
@@ -1,11 +1,11 @@
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
-from helpers.UserHelper import get_displayname_for_user
-from helpers.SetupClientHelper import substitute_inline_codes, app
 
 from pageObjects.Toolbar import Toolbar
 from helpers.UserHelper import get_displayname_for_user
-from helpers.AppHelper import app, substitute_inline_codes
+from helpers.SetupClientHelper import substitute_inline_codes
+from helpers.UserHelper import get_displayname_for_user
+from helpers.AppHelper import app
 from helpers.SyncHelper import wait_for
 
 

--- a/test/gui/pageObjects/AccountSetting.py
+++ b/test/gui/pageObjects/AccountSetting.py
@@ -5,7 +5,7 @@ from helpers.SetupClientHelper import substitute_inline_codes, app
 
 from pageObjects.Toolbar import Toolbar
 from helpers.UserHelper import get_displayname_for_user
-from helpers.SetupClientHelper import app, substitute_inline_codes
+from helpers.AppHelper import app, substitute_inline_codes
 from helpers.SyncHelper import wait_for
 
 
@@ -66,7 +66,14 @@ class AccountSetting:
 
     @staticmethod
     def get_account_connection_label():
-        label = app().find_element(AccountSetting.ACCOUNT_CONNECTION_LABEL.by, AccountSetting.ACCOUNT_CONNECTION_LABEL.selector).text
+        label = (
+            app()
+            .find_element(
+                AccountSetting.ACCOUNT_CONNECTION_LABEL.by,
+                AccountSetting.ACCOUNT_CONNECTION_LABEL.selector,
+            )
+            .text
+        )
         return label
 
     @staticmethod
@@ -109,7 +116,6 @@ class AccountSetting:
                 + " milliseconds"
             )
         return result
-
 
     @staticmethod
     def wait_until_sync_folder_is_configured(timeout=5000):

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -4,7 +4,7 @@ from appium.webdriver.common.appiumby import AppiumBy as By
 
 from helpers.FilesHelper import build_conflicted_regex
 from helpers.ConfigHelper import get_config
-from helpers.SetupClientHelper import app
+from helpers.AppHelper import app
 
 
 class Activity:
@@ -19,7 +19,6 @@ class Activity:
     SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     NOT_SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     SYNCED_ACTIVITY_STATUS = SimpleNamespace(by=By.NAME, selector=None)
-
 
     @staticmethod
     def get_not_synced_file_selector(resource):
@@ -44,10 +43,7 @@ class Activity:
     @staticmethod
     def click_tab(tab_name):
         selector = Activity.SUBTAB_CONTAINER.selector.format(tab_name=tab_name)
-        app().find_element(
-            Activity.SUBTAB_CONTAINER.by,
-            selector
-        ).click()
+        app().find_element(Activity.SUBTAB_CONTAINER.by, selector).click()
 
     @staticmethod
     def check_file_exist(filename):
@@ -62,7 +58,7 @@ class Activity:
         result = squish.waitFor(
             lambda: Activity.has_sync_status(filename, "Blacklisted"),
             get_config("maxSyncTimeout") * 1000,
-            )
+        )
         return result
 
     @staticmethod
@@ -70,7 +66,7 @@ class Activity:
         result = squish.waitFor(
             lambda: Activity.has_sync_status(filename, "File Ignored"),
             get_config("maxSyncTimeout") * 1000,
-            )
+        )
         return result
 
     @staticmethod
@@ -78,16 +74,13 @@ class Activity:
         result = squish.waitFor(
             lambda: Activity.has_sync_status(filename, "Excluded"),
             get_config("maxSyncTimeout") * 1000,
-            )
+        )
         return result
 
     @staticmethod
     def has_sync_status(filename, status):
         try:
-            app().find_element(
-                Activity.SYNCED_ACTIVITY_STATUS.by,
-                status
-            )
+            app().find_element(Activity.SYNCED_ACTIVITY_STATUS.by, status)
             return True
         except:
             return False
@@ -96,11 +89,10 @@ class Activity:
     def select_synced_filter(sync_filter):
         app().find_element(
             Activity.LOCAL_ACTIVITY_FILTER_BUTTON.by,
-            Activity.LOCAL_ACTIVITY_FILTER_BUTTON.selector
+            Activity.LOCAL_ACTIVITY_FILTER_BUTTON.selector,
         ).click()
         app().find_element(
-            Activity.SYNCED_ACTIVITY_FILTER_OPTION_SELECTOR.by,
-            sync_filter
+            Activity.SYNCED_ACTIVITY_FILTER_OPTION_SELECTOR.by, sync_filter
         )
 
     @staticmethod
@@ -155,7 +147,7 @@ class Activity:
             file_row = squish.waitForObject(
                 Activity.get_not_synced_file_selector(resource),
                 get_config("lowestSyncTimeout") * 1000,
-                )["row"]
+            )["row"]
             squish.waitForObjectExists(
                 {
                     "column": Activity.get_not_synced_table_column_number_by_name(

--- a/test/gui/pageObjects/EnterPassword.py
+++ b/test/gui/pageObjects/EnterPassword.py
@@ -3,21 +3,28 @@ from appium.webdriver.common.appiumby import AppiumBy as By
 
 from pageObjects.AccountConnectionWizard import AccountConnectionWizard
 from helpers.WebUIHelper import authorize_via_webui
-from helpers.SetupClientHelper import app
+from helpers.AppHelper import app
 
 
 class EnterPassword:
     LOGIN_CONTAINER = SimpleNamespace(by=None, selector=None)
-    LOGIN_USER_LABEL = SimpleNamespace(by=By.XPATH, selector="//filler[@name='Login required']//label[contains(@name, 'Connecting')]")
+    LOGIN_USER_LABEL = SimpleNamespace(
+        by=By.XPATH,
+        selector="//filler[@name='Login required']//label[contains(@name, 'Connecting')]",
+    )
     USERNAME_BOX = SimpleNamespace(by=None, selector=None)
     LOGOUT_BUTTON = SimpleNamespace(by=None, selector=None)
 
     def get_username(self):
         # Parse username from the login label:
-        label = app().find_element(
-            EnterPassword.LOGIN_USER_LABEL.by,
-            EnterPassword.LOGIN_USER_LABEL.selector
-        ).text
+        label = (
+            app()
+            .find_element(
+                EnterPassword.LOGIN_USER_LABEL.by,
+                EnterPassword.LOGIN_USER_LABEL.selector,
+            )
+            .text
+        )
         username = label.split(" ", maxsplit=2)[1]
         return username.capitalize()
 

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -1,8 +1,10 @@
+import pyautogui
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
 
 from helpers.ConfigHelper import get_config
+from helpers.ElementHelper import get_element_center_xy
 from helpers.SetupClientHelper import app
 
 
@@ -47,19 +49,8 @@ class SyncConnection:
                 sync_path=get_config('currentUserSyncPath'),
             ),
         )
-        # Cannot select sync folder menu button.
-        # This is a messy workaround to open the context menu using keyboard navigation.
-        # Ideally, we should be able to do: click() and send_keys(" ") to open the menu
-        # but it doesn't work for some reason.
-        # Also, send_keys(Keys.SPACE) doesn't work.
-        menu_button.click()
-        menu_button.send_keys(Keys.TAB)
-        menu_button.send_keys(Keys.TAB)
-        menu_button.send_keys(Keys.TAB)
-        menu_button.send_keys(Keys.TAB)
-        menu_button.send_keys(Keys.TAB)
-        menu_button.send_keys(Keys.TAB)
-        menu_button.send_keys(" ")
+        x, y = get_element_center_xy(menu_button)
+        pyautogui.click(x, y, button='right')
 
     @staticmethod
     def perform_action(action):

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 
 from helpers.ConfigHelper import get_config
 from helpers.ElementHelper import get_element_center_xy
-from helpers.SetupClientHelper import app
+from helpers.AppHelper import app
 
 
 class SyncConnection:

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -1,10 +1,8 @@
-import pyautogui
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
 
 from helpers.ConfigHelper import get_config
-from helpers.ElementHelper import get_element_center_xy
 from helpers.AppHelper import app
 
 
@@ -49,8 +47,7 @@ class SyncConnection:
                 sync_path=get_config('currentUserSyncPath'),
             ),
         )
-        x, y = get_element_center_xy(menu_button)
-        pyautogui.click(x, y, button='right')
+        menu_button.native_click(button='right')
 
     @staticmethod
     def perform_action(action):

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -1,10 +1,10 @@
+import pyautogui
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
-import time
-import pyautogui
 
 from helpers.SetupClientHelper import get_current_user_sync_path
+from helpers.ElementHelper import get_element_center_xy
 from helpers.SetupClientHelper import app
 
 
@@ -20,7 +20,9 @@ class SyncConnectionWizard:
     )
     REMOTE_FOLDER_TREE = SimpleNamespace(by=None, selector=None)
     SELECTIVE_SYNC_TREE_HEADER = SimpleNamespace(by=None, selector=None)
-    CANCEL_FOLDER_SYNC_CONNECTION_WIZARD = SimpleNamespace(by=By.NAME, selector="Cancel")
+    CANCEL_FOLDER_SYNC_CONNECTION_WIZARD = SimpleNamespace(
+        by=By.NAME, selector="Cancel"
+    )
     SPACES_LIST = SimpleNamespace(by=By.NAME, selector="Spaces list")
     SPACE_NAME_SELECTOR = SimpleNamespace(by=By.NAME, selector="{space_name},")
     CREATE_REMOTE_FOLDER_BUTTON = SimpleNamespace(by=None, selector=None)
@@ -71,10 +73,7 @@ class SyncConnectionWizard:
 
     @staticmethod
     def deselect_all_remote_folders():
-        element = app().find_element(
-            By.NAME,
-            "Add Space"
-        )
+        element = app().find_element(By.NAME, "Add Space")
         element.send_keys(Keys.ARROW_DOWN)
         element.send_keys(" ")
 
@@ -197,37 +196,43 @@ class SyncConnectionWizard:
         ).enabled
 
     @staticmethod
-    def select_or_unselect_folders_to_sync(
-            folders,
-            should_select=True
-    ):
-        if should_select:
+    def select_or_unselect_folders_to_sync(folders, select=True):
+        expected_state = "true" if select else "false"
+
+        if select:
             SyncConnectionWizard.deselect_all_remote_folders()
 
-        for folder in folders:
-            path_parts = folder.strip("/").split("/")
+        for folder_path in folders:
+            parents = folder_path.strip("/").split("/")
+            target_folder = parents.pop()
 
-            for i in range(len(path_parts) - 1):
-                parent_folder_name = path_parts[i]
-                parent_elements = app().find_elements(By.NAME, parent_folder_name)
+            parent_element = None
+            for parent in parents:
+                if parent_element:
+                    p_elements = parent_element.find_elements(By.NAME, parent)
+                else:
+                    p_elements = app().find_elements(By.NAME, parent)
+                for p_element in p_elements:
+                    if p_element.get_attribute("checked") == 'true':
+                        parent_element = p_element
+                px, py = get_element_center_xy(parent_element)
+                pyautogui.doubleClick(px, py)  # expand the folder
 
-                for element in parent_elements:
-                    isChecked = element.get_attribute("checked")
-                    if isChecked == "true":
-                        parent_bounds = element.rect
-                        center_x = int(parent_bounds['x'] + parent_bounds['width'] // 2)
-                        center_y = int(parent_bounds['y'] + parent_bounds['height'] // 2)
-                        pyautogui.doubleClick(center_x, center_y)
+            folder_element = app().find_element(By.NAME, target_folder)
+            is_checked = folder_element.get_attribute("checked")
+            # return early if the folder is already in the expected state.
+            if is_checked == expected_state:
+                return
 
-            target_folder_name = path_parts[-1]
-            folder_element = app().find_element(By.NAME, target_folder_name)
+            x, y = get_element_center_xy(folder_element)
+            pyautogui.click(x, y)
+            pyautogui.press('space')  # select the folder
 
-            element_bounds = folder_element.rect
-            checkbox_x_position = int(element_bounds['x'] + 10)
-            checkbox_y_position = int(element_bounds['y'] + element_bounds['height'] // 2)
-
-            pyautogui.moveTo(checkbox_x_position, checkbox_y_position, duration=0.1)
-            pyautogui.click()
+            is_checked = folder_element.get_attribute("checked")
+            if is_checked != expected_state:
+                raise AssertionError(
+                    f"Failed to {'select' if select else 'unselect'} folder: {folder_path}"
+                )
 
     @staticmethod
     def confirm_choose_what_to_sync_selection():
@@ -235,10 +240,7 @@ class SyncConnectionWizard:
 
     @staticmethod
     def __handle_folder_selection(folders, should_select, new_sync_connection_wizard):
-        SyncConnectionWizard.select_or_unselect_folders_to_sync(
-            folders,
-            should_select=should_select
-        )
+        SyncConnectionWizard.select_or_unselect_folders_to_sync(folders, should_select)
 
         if new_sync_connection_wizard:
             SyncConnectionWizard.add_sync_connection()

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -1,10 +1,8 @@
-import pyautogui
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
 
 from helpers.SetupClientHelper import get_current_user_sync_path
-from helpers.ElementHelper import get_element_center_xy
 from helpers.AppHelper import app
 
 
@@ -75,7 +73,7 @@ class SyncConnectionWizard:
     def deselect_all_remote_folders():
         element = app().find_element(By.NAME, "Add Space")
         element.send_keys(Keys.ARROW_DOWN)
-        element.send_keys(" ")
+        element.native_send_keys(Keys.SPACE)  # uncheck the root folder
 
     @staticmethod
     def sort_by(header_text):
@@ -215,8 +213,7 @@ class SyncConnectionWizard:
                 for p_element in p_elements:
                     if p_element.get_attribute("checked") == 'true':
                         parent_element = p_element
-                px, py = get_element_center_xy(parent_element)
-                pyautogui.doubleClick(px, py)  # expand the folder
+                parent_element.native_double_click()  # expand the folder
 
             folder_element = app().find_element(By.NAME, target_folder)
             is_checked = folder_element.get_attribute("checked")
@@ -224,9 +221,8 @@ class SyncConnectionWizard:
             if is_checked == expected_state:
                 return
 
-            x, y = get_element_center_xy(folder_element)
-            pyautogui.click(x, y)
-            pyautogui.press('space')  # select the folder
+            folder_element.native_click()
+            folder_element.native_send_keys(Keys.SPACE)  # select the folder
 
             is_checked = folder_element.get_attribute("checked")
             if is_checked != expected_state:

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 
 from helpers.SetupClientHelper import get_current_user_sync_path
 from helpers.ElementHelper import get_element_center_xy
-from helpers.SetupClientHelper import app
+from helpers.AppHelper import app
 
 
 class SyncConnectionWizard:

--- a/test/gui/pageObjects/Toolbar.py
+++ b/test/gui/pageObjects/Toolbar.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.webdriver.common.keys import Keys
 
-from helpers.SetupClientHelper import app, close_and_kill_app
+from helpers.AppHelper import app
 from helpers.ConfigHelper import get_config
 from helpers.UserHelper import get_displayname_for_user
 
@@ -14,13 +14,10 @@ class Toolbar:
     ADD_ACCOUNT_BUTTON = SimpleNamespace(by=By.NAME, selector="Add Account")
     ACTIVITY_BUTTON = SimpleNamespace(by=By.NAME, selector="Activity")
     SETTINGS_BUTTON = SimpleNamespace(by=None, selector=None)
-    QUIT_BUTTON = SimpleNamespace(
-        by=By.NAME,
-        selector="Quit"
-    )
+    QUIT_BUTTON = SimpleNamespace(by=By.NAME, selector="Quit")
     CONFIRM_QUIT_BUTTON = SimpleNamespace(
         by=By.ACCESSIBILITY_ID,
-        selector="QApplication.QMessageBox.qt_msgbox_buttonbox.QPushButton"
+        selector="QApplication.QMessageBox.qt_msgbox_buttonbox.QPushButton",
     )
 
     TOOLBAR_ITEMS = ["Add Account", "Activity", "Settings", "Quit"]
@@ -80,16 +77,10 @@ class Toolbar:
 
     @staticmethod
     def quit_opencloud():
+        app().find_element(Toolbar.QUIT_BUTTON.by, Toolbar.QUIT_BUTTON.selector).click()
         app().find_element(
-            Toolbar.QUIT_BUTTON.by,
-            Toolbar.QUIT_BUTTON.selector
+            Toolbar.CONFIRM_QUIT_BUTTON.by, Toolbar.CONFIRM_QUIT_BUTTON.selector
         ).click()
-        app().find_element(
-            Toolbar.CONFIRM_QUIT_BUTTON.by,
-            Toolbar.CONFIRM_QUIT_BUTTON.selector
-        ).click()
-        close_and_kill_app()
-
 
     @staticmethod
     def get_accounts():

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -16,7 +16,6 @@ from helpers.SetupClientHelper import (
     get_client_details,
     generate_account_config,
     get_resource_path,
-    app,
 )
 from helpers.SyncHelper import (
     wait_for_initial_sync_to_complete,
@@ -123,7 +122,7 @@ def step(context, username):
 @Then('user "{username}" should be signed out')
 def step(context, username):
     user_signed_out = AccountSetting.is_user_signed_out()
-    
+
     with ensure('User "{0}" should be signed out, but is still signed in', username):
         user_signed_out.should.be.true
 


### PR DESCRIPTION
Bind some usefule mouse and keyboard actions to appium element class.

- new helpers:
  - `ElementHelper.py`
  - `AppHelper.py`
- new methods available to element object: (binding pyautogui methods to appium element class)
  - `native_click(...)`: `pyautogui.click(...)`
  - `native_double_click(...)`: `pyautogui.doubleClick(...)`
  - `native_send_keys(...)`: `pyautogui.press(...)`

Usage:
```py
element = app().find_element(By.NAME, "Close")
element.native_click()
```