### PR TITLE
test(gui): capture and store video for failed scenarios

### DIFF
--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -5,6 +5,7 @@ import pyautogui
 from behave.model_core import Status
 from datetime import datetime
 
+from helpers import ScreenRecorder
 from helpers.ConfigHelper import init_config
 from helpers.api.provisioning import delete_created_users
 from helpers.SpaceHelper import delete_project_spaces
@@ -43,6 +44,11 @@ def before_feature(context, feature):
     init_config()
 
 
+def before_scenario(context, scenario):
+    if os.getenv("CI"):
+        ScreenRecorder.start_recording(scenario)
+
+
 def after_step(context, step):
     if step.status in [Status.failed, Status.error] and os.getenv("CI"):
         scenario = context.scenario.name.lower()
@@ -56,6 +62,11 @@ def after_step(context, step):
 
 
 def after_scenario(context, scenario):
+
+    # stop screen recording
+    if os.getenv("CI"):
+        ScreenRecorder.stop_recording(passed=scenario.status == Status.passed)
+
     # clean up sync dir
     if os.path.exists(get_config("clientRootSyncPath")):
         for entry in os.scandir(get_config("clientRootSyncPath")):

--- a/test/gui/helpers/ScreenRecorder.py
+++ b/test/gui/helpers/ScreenRecorder.py
@@ -1,0 +1,82 @@
+import os
+import re
+import threading
+import time
+import mss
+import numpy as np
+import imageio_ffmpeg
+from datetime import datetime
+
+from helpers.ConfigHelper import get_config
+
+
+_recording_thread = None
+_stop_event = threading.Event()
+_video_path = None
+
+
+def _build_video_path(scenario):
+    safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", scenario.name)
+    timestamp = datetime.now().strftime("%d-%b-%Y_%H-%M-%S")
+
+    recordings_dir = os.path.join(get_config("guiTestReportDir"), "recordings")
+    os.makedirs(recordings_dir, exist_ok=True)
+
+    return os.path.join(recordings_dir, f"{safe_name}_{timestamp}.mp4")
+
+
+def _record_loop(video_path):
+    with mss.mss() as sct:
+        monitor = sct.monitors[0]
+        width, height = monitor["width"], monitor["height"]
+
+        writer = imageio_ffmpeg.write_frames(
+            video_path,
+            size=(width, height),
+            fps=24,
+            codec="libx264",
+            output_params=["-crf", "23", "-pix_fmt", "yuv420p"],
+        )
+        writer.send(None)
+
+        interval = 1.0 / 24 # 1/24 seconds between each frame so we get 24 frames per second
+        next_frame_at = time.monotonic()
+
+        while not _stop_event.is_set():
+            frame = sct.grab(monitor)
+            # mss gives BGRA — drop alpha, flip B and R channels to get RGB
+            rgb = np.flip(np.array(frame)[:, :, :3], axis=2).tobytes()
+            writer.send(rgb)
+
+            next_frame_at += interval
+            sleep_for = next_frame_at - time.monotonic()
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+
+        writer.close()
+
+
+def start_recording(scenario):
+    global _recording_thread, _video_path
+
+    _video_path = _build_video_path(scenario)
+    _stop_event.clear()
+
+    _recording_thread = threading.Thread(target=_record_loop, args=(_video_path,), daemon=True)
+    _recording_thread.start()
+
+
+def stop_recording(passed):
+    global _recording_thread, _video_path
+
+    if _recording_thread is None:
+        return
+
+    _stop_event.set()
+    _recording_thread.join()
+    _recording_thread = None
+
+    if passed and os.path.exists(_video_path):
+        os.remove(_video_path)
+
+    _video_path = None

--- a/test/gui/requirements.txt
+++ b/test/gui/requirements.txt
@@ -18,3 +18,5 @@ numpy==1.26.*; python_version >= "3.10" and sys_platform == 'linux'
 sure==2.0.*; python_version >= "3.10"
 pyautogui==0.9.*; python_version >= "3.10"
 behave-html-pretty-formatter==1.16.*; python_version >= "3.10"
+mss==9.*; python_version >= "3.10"
+imageio-ffmpeg==0.6.*; python_version >= "3.10"

--- a/test/gui/woodpecker/gui_test_reports.sh
+++ b/test/gui/woodpecker/gui_test_reports.sh
@@ -20,3 +20,16 @@ if [[ -n "$screenshots" ]]; then
 else
   echo "No screenshots found."
 fi
+
+recordings=$(mc find s3/$REPORT_PATH/recordings/ 2>/dev/null || true)
+if [[ -n "$recordings" ]]; then
+  echo ""
+  echo "Recordings:"
+  for f in $recordings; do
+    # remove 's3/' prefix
+    f=${f/s3\//}
+    echo "  - $MC_HOST/$f"
+  done
+else
+  echo "No recordings found."
+fi


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861


This PR adds a screenrecorder helper.
Adds a `before_scenario` hook to start recording and only save the video if the scenario fails.
"

Use the python packages: `mss` and `inputio-ffmpeg`