### PR TITLE
fix: 🐛 send single 'prompt' value so Entra ID OIDC works

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -346,7 +346,7 @@ QString Theme::openIdConnectScopes() const
 
 QString Theme::openIdConnectPrompt() const
 {
-    return QStringLiteral("select_account consent");
+    return QStringLiteral("consent");
 }
 
 bool Theme::oidcEnableDynamicRegistration() const


### PR DESCRIPTION
## Summary

Microsoft Entra ID rejects the authorize call with `AADSTS90023: Unsupported 'prompt' value` because the desktop client sends two values (`select_account consent`). Entra accepts only one of `login`/`none`/`consent`/`select_account`/`create`. Other IdPs (Keycloak, Okta) are lenient and accept the space-separated form, which is why the bug hasn't surfaced sooner.

The discovery-doc filter in `OAuth::fetchWellKnown` already narrows `_supportedPromtValues` against `prompt_values_supported`, but Entra doesn't publish that field, so the client falls back to the default and the request fails before the browser can complete.

## Change

Drop `select_account` from `Theme::openIdConnectPrompt()`, keep `consent`. One-line change in `src/libsync/theme.cpp`. Entra still shows an account picker on first sign-in to a tenant, and the desktop client's own multi-account wizard covers the "switch accounts" case.

## Repro (current behaviour)

```
https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize
  ?response_type=code
  &client_id=<...>
  &redirect_uri=http://127.0.0.1:50404
  &code_challenge=<...>&code_challenge_method=S256
  &scope=openid+offline_access+email+profile
  &prompt=consent+select_account
  &state=<...>
  &login_hint=<user@email>
```

Response: `AADSTS90023: Unsupported 'prompt' value`.

## Refs

- Fixes #871
- Same root cause as owncloud/client#8562 (legacy fork, same code path in `src/libsync/theme.cpp`)
- AADSTS90023 reference: https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes

## Follow-up (not in this PR)

The hardcoded `oauthClientId()` (returns `"OpenCloudDesktop"`) only works against IdPs that accept a string client_id, or where the oCIS-side registration endpoint hands the client a dynamic registration. Entra requires a registered app with a GUID client_id, and dynamic registration isn't an option there. That's a separate, larger change (likely an oCIS-side server config field surfaced via the existing well-known/server-config fetch). Happy to scope it as a follow-up PR if there's interest.