### PR TITLE
test(gui): port filter not synced activities feature to appium 

### DIFF
--- a/test/gui/features/activity/activity.feature
+++ b/test/gui/features/activity/activity.feature
@@ -23,7 +23,7 @@ Feature: filter activity for user
             | resource     | action     | account                              |
             | brian-folder | Downloaded | Brian Murphy@%local_server_hostname% |
 
-    @skipOnWindows @skip
+    @skipOnWindows
     Scenario: filter not synced activities (Linux only)
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings

--- a/test/gui/features/activity/activity.feature
+++ b/test/gui/features/activity/activity.feature
@@ -41,6 +41,7 @@ Feature: filter activity for user
             | resource         | status      | account                              |
             | Folder1/a\\a.txt | Blacklisted | Alice Hansen@%local_server_hostname% |
 
+
     @skipOnLinux @skip
     Scenario: filter not synced activities (Windows only)
         Given user "Alice" has been created in the server with default attributes

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -7,6 +7,7 @@ from selenium.common.exceptions import NoSuchElementException
 from helpers.FilesHelper import build_conflicted_regex
 from helpers.ConfigHelper import get_config
 from helpers.AppHelper import app
+from helpers.SyncHelper import wait_for
 
 
 class Activity:
@@ -21,7 +22,9 @@ class Activity:
     FILTER_BUTTON_SELECTED_STATE = SimpleNamespace(
         by=By.XPATH, selector="//*[contains(@name, '1 Filter')]"
     )
-    NOT_SYNCED_FILTER_BUTTON = SimpleNamespace(by=None, selector=None)
+    NOT_SYNCED_FILTER_BUTTON = SimpleNamespace(by=By.ACCESSIBILITY_ID,
+         selector="QApplication.Settings.centralwidget.dialogStack.page.stack.OCC::ActivitySettings.QTabWidget.qt_tabwidget_stackedwidget.OCC__IssuesWidget._filterButton"
+    )
     NOT_SYNCED_FILTER_OPTION_SELECTOR = SimpleNamespace(by=None, selector=None)
     SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     NOT_SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
@@ -62,7 +65,7 @@ class Activity:
 
     @staticmethod
     def is_resource_blacklisted(filename):
-        result = squish.waitFor(
+        result = wait_for(
             lambda: Activity.has_sync_status(filename, "Blacklisted"),
             get_config("maxSyncTimeout") * 1000,
         )
@@ -78,7 +81,7 @@ class Activity:
 
     @staticmethod
     def is_resource_excluded(filename):
-        result = squish.waitFor(
+        result = wait_for(
             lambda: Activity.has_sync_status(filename, "Excluded"),
             get_config("maxSyncTimeout") * 1000,
         )
@@ -164,12 +167,16 @@ class Activity:
 
     @staticmethod
     def select_not_synced_filter(filter_option):
-        squish.clickButton(squish.waitForObject(Activity.NOT_SYNCED_FILTER_BUTTON))
-        squish.activateItem(
-            squish.waitForObjectItem(
-                Activity.NOT_SYNCED_FILTER_OPTION_SELECTOR, filter_option
-            )
-        )
+        menu = app().find_element(
+            Activity.NOT_SYNCED_FILTER_BUTTON.by,
+            Activity.NOT_SYNCED_FILTER_BUTTON.selector)
+        menu.click()
+        # NOTE: Filter options are not visible in the accessibility tree.
+        # As a workaround, select the 6th filter option (which is an Excluded filter).
+        # This means we cannot select a specific Excluded filter for now.
+        for _ in range(6):
+            menu.send_keys(Keys.ARROW_DOWN)
+        menu.send_keys(Keys.ENTER)
 
     @staticmethod
     def get_not_synced_table_column_number_by_name(column_name):

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -290,9 +290,9 @@ def step(context, resource_type, resource_name):
     deleteResource(resource_name, resource_type)
 
 
-@When('user "|any|" creates the following files inside the sync folder:')
+@When('user "{username}" creates the following files inside the sync folder:')
 def step(context, username):
-    for row in context.table[1:]:
+    for row in context.table:
         file = get_resource_path(row[0], username)
         wait_and_write_file(file, '')
 

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -21,6 +21,23 @@ from helpers.FilesHelper import convert_path_separators_for_os
 from helpers.TableParser import table_hashes, table_raw
 
 
+def _check_activities(context, not_synced=False):
+    field = "status" if not_synced else "action"
+    activities = table_hashes(context.table)
+    for activity in activities:
+        activity["account"] = substitute_inline_codes(activity["account"])
+        has_activity = Activity.has_activity(
+            activity["resource"], activity[field], activity["account"]
+        )
+        with ensure(
+            'Activity should exist: {0} | {1} | {2}',
+            activity["resource"],
+            activity[field],
+            activity["account"],
+        ):
+            has_activity.should.be.true
+
+
 @Given('the user has paused the file sync')
 def step(context):
     SyncConnection.pause_sync()
@@ -93,11 +110,12 @@ def step(context, filename):
     Activity.check_file_exist(filename)
 
 
-@Then('the file "|any|" should be blacklisted')
+@Then('the file "{filename}" should be blacklisted')
 def step(context, filename):
-    test.compare(
-        True, Activity.is_resource_blacklisted(filename), 'File is Blacklisted'
-    )
+   with ensure(
+       'File is Blacklisted'
+   ):
+    Activity.is_resource_blacklisted(filename).should.be.true
 
 
 @Then('the file "|any|" should be ignored')
@@ -105,9 +123,12 @@ def step(context, filename):
     test.compare(True, Activity.is_resource_ignored(filename), 'File is Ignored')
 
 
-@Then('the file "|any|" should be excluded')
+@Then('the file "{filename}" should be excluded')
 def step(context, filename):
-    test.compare(True, Activity.is_resource_excluded(filename), 'File is Excluded')
+    with ensure(
+       'File is Excluded'
+   ):
+        Activity.is_resource_excluded(filename).should.be.true
 
 
 @When('the user selects "{tab_name}" tab in the activity')
@@ -289,19 +310,12 @@ def step(context, account):
 
 @Then('the following activities should be displayed in synced table')
 def step(context):
-    activities = table_hashes(context.table)
-    for activity in activities:
-        activity["account"] = substitute_inline_codes(activity["account"])
-        has_activity = Activity.has_activity(
-            activity["resource"], activity["action"], activity["account"]
-        )
-        with ensure(
-            'Activity should exist: {0} | {1} | {2}',
-            activity["resource"],
-            activity["action"],
-            activity["account"],
-        ):
-            has_activity.should.be.true
+    _check_activities(context)
+
+
+@Then('the following activities should be displayed in not synced table')
+def step(context):
+    _check_activities(context, not_synced=True)
 
 
 @Then('the following activities should not be displayed in synced table')
@@ -338,7 +352,7 @@ def step(context, should_or_should_not):
         )
 
 
-@When('the user unchecks the "|any|" filter')
+@When('the user unchecks the "{filter_option}" filter')
 def step(context, filter_option):
     Activity.select_not_synced_filter(filter_option)
 

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -21,7 +21,7 @@ from helpers.FilesHelper import convert_path_separators_for_os
 from helpers.TableParser import table_hashes, table_raw
 
 
-def _check_activities(context, not_synced=False):
+def _check_activities(context, not_synced=False, should_exist=True):
     field = "status" if not_synced else "action"
     activities = table_hashes(context.table)
     for activity in activities:
@@ -35,7 +35,10 @@ def _check_activities(context, not_synced=False):
             activity[field],
             activity["account"],
         ):
-            has_activity.should.be.true
+            if should_exist:
+                has_activity.should.be.true
+            else:
+                has_activity.should.be.false
 
 
 @Given('the user has paused the file sync')
@@ -316,40 +319,17 @@ def step(context):
 @Then('the following activities should be displayed in not synced table')
 def step(context):
     _check_activities(context, not_synced=True)
-
+    
 
 @Then('the following activities should not be displayed in synced table')
 def step(context):
-    activities = table_hashes(context.table)
-    for activity in activities:
-        activity["account"] = substitute_inline_codes(activity["account"])
-        has_activity = Activity.has_activity(
-            activity["resource"], activity["action"], activity["account"]
-        )
-        with ensure(
-            'Activity should not exist: {0} | {1} | {2}',
-            activity["resource"],
-            activity["action"],
-            activity["account"],
-        ):
-            has_activity.should.be.false
+    _check_activities(context, should_exist=False)
 
 
-@Then(
-    r'the following activities (should|should not) be displayed in not synced table',
-    regexp=True,
-)
-def step(context, should_or_should_not):
-    expected = should_or_should_not == "should"
-    for row in context.table[1:]:
-        resource = row[0]
-        status = row[1]
-        account = substitute_inline_codes(row[2])
-        test.compare(
-            Activity.check_not_synced_table(resource, status, account),
-            expected,
-            'Resource should be displayed in the not synced table',
-        )
+@Then('the following activities should not be displayed in not synced table')
+def step(context):
+    _check_activities(context, not_synced=True, should_exist=False)
+
 
 
 @When('the user unchecks the "{filter_option}" filter')


### PR DESCRIPTION
Part of: #861

This PR enables the following activity test:

```feature
Scenario: filter not synced activities (Linux only)
```
```feature
Scenario: filter not synced activities (Windows only)
```

Reduced duplicate code in activity validation steps by using a common helper function for both displayed and not displayed activity checks.
