### PR TITLE
test(ci): add @skip tag to exclude scenario from CI execution

### DIFF
--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -127,7 +127,7 @@ steps:
       GUI_TEST_REPORT_DIR: /woodpecker/desktop/test/gui/reports
       BEHAVE_TEST_DIR: /woodpecker/desktop/test/gui
       # Cannot handle this tags format inside a container: --tags='@smoke and not @skip'
-      BEHAVE_PARAMETERS: '--tags=@smoke --tags=~@skip ${SUITES}'
+      BEHAVE_PARAMETERS: '--tags=~@skip ${SUITES}'
 
   # - name: crash-log
   #   image: *alpine_image

--- a/test/gui/features/activity/activity.feature
+++ b/test/gui/features/activity/activity.feature
@@ -23,7 +23,7 @@ Feature: filter activity for user
             | resource     | action     | account                              |
             | brian-folder | Downloaded | Brian Murphy@%local_server_hostname% |
 
-    @skipOnWindows
+    @skipOnWindows @skip
     Scenario: filter not synced activities (Linux only)
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings
@@ -41,7 +41,7 @@ Feature: filter activity for user
             | resource         | status      | account                              |
             | Folder1/a\\a.txt | Blacklisted | Alice Hansen@%local_server_hostname% |
 
-    @skipOnLinux
+    @skipOnLinux @skip
     Scenario: filter not synced activities (Windows only)
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings

--- a/test/gui/features/add-account/account.feature
+++ b/test/gui/features/add-account/account.feature
@@ -6,7 +6,7 @@ Feature: adding accounts
     Background:
         Given user "Alice" has been created in the server with default attributes
 
-
+    @skip
     Scenario: Check default options in advanced configuration
         Given the user has started the client
         And the user has entered the following account information:
@@ -38,7 +38,7 @@ Feature: adding accounts
         Then "Brian" account should be opened
         And "Alice" account should be added
 
-
+    @skip
     Scenario: Adding account with self signed certificate for the first time
         Given the user has started the client
         When the user adds the server "%local_server%"
@@ -61,7 +61,7 @@ Feature: adding accounts
         And the user syncs the "Personal" space
         Then the folder "simple-folder" should exist on the file system
 
-
+    @skip
     Scenario: Check for suffix when sync path exists
         Given the user has created folder "OpenCloud" in the default home path
         And the user has started the client

--- a/test/gui/features/delete-files-folders/delete.feature
+++ b/test/gui/features/delete-files-folders/delete.feature
@@ -46,7 +46,7 @@ Feature: deleting files and folders
         And as "Alice" file "textfile2.txt" should exist in the server
         And as "Alice" folder "test-folder2" should exist in the server
 
-
+    @skip
     Scenario: Delete multiple files
         Given user "Alice" has uploaded the following files to the server
             | file          | content                     |
@@ -65,7 +65,7 @@ Feature: deleting files and folders
             | textfile1.txt |
         And as "Alice" file "textfile2.txt" should exist in the server
 
-
+    @skip
     Scenario Outline: Create and delete a file with special characters
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "<fileName>" with the following content inside the sync folder

--- a/test/gui/features/edit-files/edit.feature
+++ b/test/gui/features/edit-files/edit.feature
@@ -26,7 +26,7 @@ Feature: edit files
         And the user waits for file "testfile.txt" to be synced
         Then as "Alice" the file "testfile.txt" should have the content "overwrite openCloud test text file" in the server
 
-
+    @skip
     Scenario Outline: Replace and modify the content of a file multiple times
         Given user "Alice" has set up a client with default settings
         And the user has copied file "<initialFile>" from outside the sync folder to "/" in the sync folder

--- a/test/gui/features/move-files-folders/moveFilesFolders.feature
+++ b/test/gui/features/move-files-folders/moveFilesFolders.feature
@@ -11,7 +11,7 @@ Feature: move file and folder
         And user "Alice" has created folder "folder1/folder2/folder3/folder4" in the server
         And user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5" in the server
 
-
+    @skip
     Scenario: Move folder and file from level 5 sub-folder to sync root
         Given user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5/test-folder" in the server
         And user "Alice" has uploaded file with content "openCloud" to "folder1/folder2/folder3/folder4/folder5/lorem.txt" in the server
@@ -24,7 +24,7 @@ Feature: move file and folder
         And as "Alice" file "folder1/folder2/folder3/folder4/folder5/lorem.txt" should not exist in the server
         And as "Alice" folder "folder1/folder2/folder3/folder4/folder5/test-folder" should not exist in the server
 
-
+    @skip
     Scenario: Move two folders and a file down to the level 5 sub-folder
         And user "Alice" has created folder "test-folder1" in the server
         And user "Alice" has created folder "test-folder2" in the server
@@ -67,7 +67,7 @@ Feature: move file and folder
         And as "Alice" file "folder1/file2.txt" should not exist in the server
 
 
-
+    @skip
     Scenario: Move resources from different sub-levels to sync root
         Given user "Alice" has created folder "folder1/folder2/folder3/folder4/test-folder" in the server
         And user "Alice" has uploaded file with content "openCloud" to "folder1/folder2/lorem.txt" in the server
@@ -80,7 +80,7 @@ Feature: move file and folder
         And as "Alice" file "folder1/folder2/lorem.txt" should not exist in the server
         And as "Alice" folder "folder1/folder2/folder3/folder4/test-folder" should not exist in the server
 
-
+    @skip
 	Scenario: Syncing a 50MB file moved into the local sync folder
         Given user "Alice" has set up a client with default settings
         And user "Alice" has created a folder "NewFolder" inside the sync folder

--- a/test/gui/features/remove-account-connection/removeAccountConnection.feature
+++ b/test/gui/features/remove-account-connection/removeAccountConnection.feature
@@ -15,7 +15,7 @@ Feature: remove account connection
         Then "Brian" account should not be displayed
         But "Alice" account should be added
 
-
+    @skip
     Scenario: remove the only account connection
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has created folder "large-folder" in the server

--- a/test/gui/features/spaces/spaces.feature
+++ b/test/gui/features/spaces/spaces.feature
@@ -16,7 +16,7 @@ Feature: Project spaces
         Then user "Alice" should be able to open the file "testfile.txt" on the file system
         And as "Alice" the file "testfile.txt" should have content "some content" on the file system
 
-
+    @skip
     Scenario: User with Viewer role cannot edit the file
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
@@ -68,7 +68,7 @@ Feature: Project spaces
         Then for user "Alice" sync folder "Project101" should not be displayed
         But the file "testfile.txt" should exist on the file system
 
-
+    @skip
     Scenario: User with Viewer role cannot create resource
         Given the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with space "Project101"

--- a/test/gui/features/sync-resources/syncResources.feature
+++ b/test/gui/features/sync-resources/syncResources.feature
@@ -33,7 +33,7 @@ Feature: Syncing files
         And the folder "simple-folder" should exist on the file system
         And the folder "large-folder" should exist on the file system
 
-    @issue-9733
+    @issue-9733 @skip
     Scenario: Syncing a file from the server and creating a conflict
         Given user "Alice" has uploaded file with content "server content" to "/conflict.txt" in the server
         And user "Alice" has set up a client with default settings
@@ -57,7 +57,7 @@ Feature: Syncing files
             client content
             """
 
-    @skipOnWindows
+    @skipOnWindows @skip
     Scenario: Sync all is selected by default
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created folder "large-folder" in the server
@@ -110,7 +110,7 @@ Feature: Syncing files
         And the file "large-folder/lorem.txt" should not exist on the file system
         And as "Alice" file "simple-folder/localFile.txt" should exist in the server
 
-    @issue-9733 @skipOnWindows
+    @issue-9733 @skipOnWindows @skip
     Scenario: sort folders list by name and size
         Given user "Alice" has created folder "123Folder" in the server
         And user "Alice" has uploaded file with content "small" to "123Folder/lorem.txt" in the server
@@ -165,7 +165,7 @@ Feature: Syncing files
             | "myFolder"                                                               |
             | "really long folder name with some spaces and special char such as $%ñ&" |
 
-    @skipOnWindows
+    @skipOnWindows @skip
     Scenario Outline: Syncing a folder having space at the end (Linux only)
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder <foldername> inside the sync folder
@@ -175,7 +175,7 @@ Feature: Syncing files
             | foldername                  |
             | "folder with space at end " |
 
-    @skipOnLinux
+    @skipOnLinux @skip
     Scenario: Try to sync files having space at the end (Windows only)
         Given user "Alice" has uploaded file with content "lorem epsum" to "trailing-space.txt " in the server
         And user "Alice" has set up a client with default settings
@@ -266,7 +266,7 @@ Feature: Syncing files
         And as "Alice" folder "Folder1/subFolder1" should exist in the server
         And as "Alice" folder "Folder1/subFolder1/subFolder2" should exist in the server
 
-    @skipOnWindows
+    @skipOnWindows @skip
     Scenario: Filenames that are rejected by the server are reported (Linux only)
         Given user "Alice" has created folder "Folder1" in the server
         And user "Alice" has set up a client with default settings
@@ -279,7 +279,7 @@ Feature: Syncing files
         Then the file "Folder1/a\\a.txt" should exist on the file system
         And the file "Folder1/a\\a.txt" should be blacklisted
 
-
+    @skip
     Scenario Outline: Sync long nested folder
         Given user "Alice" has created folder "<foldername>" in the server
         And user "Alice" has set up a client with default settings
@@ -312,7 +312,7 @@ Feature: Syncing files
         And as "Alice" file "/PRN" should exist in the server
         And as "Alice" file "/foo%" should exist in the server
 
-    @skipOnLinux
+    @skipOnLinux @skip
     Scenario: Sync invalid system names (Windows only)
         Given user "Alice" has created folder "CON" in the server
         And user "Alice" has created folder "test%" in the server
@@ -348,7 +348,7 @@ Feature: Syncing files
         And the file "simple-folder/simple.pptx" should exist on the file system
         And the file "simple-folder/simple.xlsx" should exist on the file system
 
-
+    @skip
     Scenario: various types of files can be synced from client to server
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates the following files inside the sync folder:
@@ -393,7 +393,7 @@ Feature: Syncing files
         And the user waits for file "newfile.txt" to be synced
         Then as "Alice" file "newfile.txt" should exist in the server
 
-
+    @skip
     Scenario: File with spaces in the name can sync
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "file with space.txt" with the following content inside the sync folder
@@ -403,7 +403,7 @@ Feature: Syncing files
         And the user waits for file "file with space.txt" to be synced
         Then as "Alice" file "file with space.txt" should exist in the server
 
-
+    @skip
     Scenario: Syncing folders each having large number of files
         Given the user has created a folder "folder1" in temp folder
         And the user has created "500" files each of size "1048576" bytes inside folder "folder1" in temp folder
@@ -438,7 +438,7 @@ Feature: Syncing files
         And for user "Alice" sync folder "Personal" should not be displayed
         And for user "Alice" sync folder "Shares" should not be displayed
 
-
+    @skip
     Scenario: extract a zip file in the sync folder
         Given the user has created a zip file "archive.zip" with the following resources in the temp folder
             | resource  | type   | content    |
@@ -456,7 +456,7 @@ Feature: Syncing files
         And as "Alice" the file "file2.txt" should have the content "Test file2" in the server
 
 
-    @skipOnWindows
+    @skipOnWindows @skip
     Scenario: sync remote folder to a local sync folder having special characters
         Given user "Alice" has created folder "~`!@#$^&()-_=+{[}];',)" in the server
         And user "Alice" has created folder "simple-folder" in the server
@@ -487,14 +487,14 @@ Feature: Syncing files
         And the folder "test-folder/sub-folder2" should exist on the file system
         And the folder "test-folder/sub-folder1" should not exist on the file system
 
-
+    @skip
     Scenario: Syncing a local folder having special characters to the server
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" inside the sync folder
         And the user waits for folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" to be synced
         Then as "Alice" folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" should exist in the server
 
-    @issue-11814
+    @issue-11814 @skip
     Scenario: Remove folder sync connection (Personal Space)
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
@@ -503,7 +503,7 @@ Feature: Syncing files
         And the folder "simple-folder" should exist on the file system
         And as "Alice" folder "simple-folder" should exist in the server
 
-
+    @skip
     Scenario: Sync a received shared folder with Viewer permission role
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "simple-folder" in the server
@@ -534,7 +534,7 @@ Feature: Syncing files
             | simple-folder/sub-folder | Blacklisted | Brian Murphy@%local_server_hostname% |
             | simple-folder/simple.pdf | Blacklisted | Brian Murphy@%local_server_hostname% |
 
-
+    @skip
     Scenario Outline: File with long multi-byte characters name can be synced (76 characters, 255 bytes including extension)
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "<filename>" with the following content inside the sync folder
@@ -547,7 +547,7 @@ Feature: Syncing files
             | filename                                                                    |
             | 𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺abôǣฎพฒฆ๘ตกกผพฒณญไใๅำ๊๒๔๗๘รศฬอฮ.txt |
 
-
+    @skip
 	Scenario: Sync a received shared folder with Editor permission role
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "simple-folder" in the server
@@ -585,7 +585,7 @@ Feature: Syncing files
         And the user waits for the files to sync
         Then the file "test-folder/sub-folder2/lorem.txt" should not exist on the file system
 
-    @skipOnWindows
+    @skipOnWindows @skip
     Scenario: Only root level files sync when all folders are unselected
         Given user "Alice" has created folder "test-folder" in the server
         And user "Alice" has created folder "test-folder/sub-folder1" in the server

--- a/test/gui/features/vfs/vfs.feature
+++ b/test/gui/features/vfs/vfs.feature
@@ -4,7 +4,7 @@ Feature: VFS support
     I want to sync files with vfs
     So that I can decide which files to download
 
-
+    @skip
     Scenario: Default VFS sync
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "openCloud" to "testFile.txt" in the server
@@ -17,7 +17,7 @@ Feature: VFS support
         Then the file "parent/lorem.txt" should be downloaded
         And the placeholder file "testFile.txt" should exist on the file system
 
-
+    @skip
     Scenario: Copy placeholder file
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "sample file" to "sampleFile.txt" in the server
@@ -43,7 +43,7 @@ Feature: VFS support
         And as "Alice" file "testFile.txt" should exist in the server
         And as "Alice" file "testFile (Copy).txt" should exist in the server
 
-
+    @skip
     Scenario: Move placeholder file
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "lorem file" to "lorem.txt" in the server
@@ -58,7 +58,7 @@ Feature: VFS support
         And as "Alice" file "lorem.txt" should not exist in the server
         And as "Alice" file "sampleFile.txt" should not exist in the server
 
-
+    @skip
     Scenario: Hydration and dehydration of files via file explorer
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "test content" to "testFile.txt" in the server
@@ -101,7 +101,7 @@ Feature: VFS support
         And the user waits for file "simple.txt" to be synced
         Then the placeholder file "simple.txt" should exist on the file system
 
-
+    @skip
     Scenario: Hydration and dehydration of folders via file explorer
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has created folder "testFol" in the server


### PR DESCRIPTION
This change adds the @Skip tag to specific test scenarios to exclude them from CI execution.

Previously, non-smoke tests also required @smoke tag to run in CI, which caused confusion. This change separates CI inclusion (@smoke) and exclusion (@skip) for clearer test control.

---
Now the workflow will be :
- skip all the tests that are not tagged @smoke
- fix and enable skipped tests
- in CI, run tests that are not marked @skip

@saw-jan @prashant-gurung899  Should I keep the @smoke tag now or not?