### PR TITLE
tests(GUI): enable edit and remove acc connection tests

### DIFF
--- a/test/gui/features/edit-files/edit.feature
+++ b/test/gui/features/edit-files/edit.feature
@@ -26,14 +26,12 @@ Feature: edit files
         And the user waits for file "testfile.txt" to be synced
         Then as "Alice" the file "testfile.txt" should have the content "overwrite openCloud test text file" in the server
 
-    @skip
+
     Scenario Outline: Replace and modify the content of a file multiple times
         Given user "Alice" has set up a client with default settings
         And the user has copied file "<initialFile>" from outside the sync folder to "/" in the sync folder
         When the user copies file "<updateFile1>" from outside the sync folder to "/<initialFile>" in the sync folder
-        And the user waits for the files to sync
         And the user copies file "<updateFile2>" from outside the sync folder to "/<initialFile>" in the sync folder
-        And the user waits for the files to sync
         And the user copies file "<updateFile3>" from outside the sync folder to "/<initialFile>" in the sync folder
         And the user waits for the files to sync
         Then as "Alice" the content of file "<initialFile>" in the server should match the content of local file "<updateFile3>"

--- a/test/gui/features/remove-account-connection/removeAccountConnection.feature
+++ b/test/gui/features/remove-account-connection/removeAccountConnection.feature
@@ -15,7 +15,7 @@ Feature: remove account connection
         Then "Brian" account should not be displayed
         But "Alice" account should be added
 
-    @skip
+
     Scenario: remove the only account connection
         Given user "Alice" has been created in the server with default attributes
         And user "Alice" has created folder "large-folder" in the server

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -429,7 +429,7 @@ def step(context, folder_name):
 
 
 @Given(
-    r'the user has copied file "([^"]*)" from outside the sync folder to "([^"]*)" in the sync folder',
+    'the user has copied file "{resource_name}" from outside the sync folder to "{destination}" in the sync folder',
     regexp=True,
 )
 def step(context, resource_name, destination):
@@ -437,7 +437,7 @@ def step(context, resource_name, destination):
 
 
 @When(
-    r'the user copies file "([^"]*)" from outside the sync folder to "([^"]*)" in the sync folder',
+    'the user copies file "{resource_name}" from outside the sync folder to "{destination}" in the sync folder',
     regexp=True,
 )
 def step(context, resource_name, destination):

--- a/test/gui/steps/server_context.py
+++ b/test/gui/steps/server_context.py
@@ -1,8 +1,11 @@
+import tempfile
+from pathlib import Path
 from behave import given as Given, then as Then
 from sure import ensure
 
 from helpers.api import provisioning, webdav_helper as webdav
 from helpers.TableParser import table_rows_hash
+from helpers.FilesHelper import get_file_for_upload, get_document_content
 
 
 @Given('user "{user}" has been created in the server with default attributes')
@@ -96,7 +99,7 @@ def step(context, user, file_name, destination):
 
 
 @Then(
-    'as "|any|" the content of file "|any|" in the server should match the content of local file "|any|"'
+    'as "{user_name}" the content of file "{server_file_name}" in the server should match the content of local file "{local_file_name}"'
 )
 def step(context, user_name, server_file_name, local_file_name):
     raw_server_content = webdav.get_file_content(user_name, server_file_name)
@@ -108,11 +111,10 @@ def step(context, user_name, server_file_name, local_file_name):
         server_content = get_document_content(tmp_file.name)
     local_content = get_document_content(get_file_for_upload(local_file_name))
 
-    test.compare(
-        server_content,
-        local_content,
-        f"Server file '{server_file_name}' differs from local file '{local_file_name}'",
-    )
+    with ensure(
+            f"Server file '{server_file_name}' differs from local file '{local_file_name}'",
+    ):
+        server_content.should.equal(local_content)
 
 
 @Then('as "{user_name}" following files should not exist in the server',)
@@ -124,7 +126,7 @@ def step(context, user_name):
              f"Resource '{resource_name}' should not exist, but it does",
         ):
             resource_exists.should.be.false
-    
+
 
 
 @Given('user "{user}" has uploaded the following files to the server')


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861

Enables following scenarios:


- `features/edit-files/edit.feature:30`
```feature
Scenario Outline: Replace and modify the content of a file multiple times
```
- `features/remove-account-connection/removeAccountConnection.feature:19`
```feature
Scenario: remove the only account connection
```