### PR TITLE
test(gui): enable more sync resources tests

### DIFF
--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -29,6 +29,7 @@ class Activity:
     NOT_SYNCED_FILTER_OPTION_SELECTOR = SimpleNamespace(by=None, selector=None)
     SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     NOT_SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
+    NOT_SYNCED_ACTIVITY_CONFLICT_FILE = SimpleNamespace(by=By.XPATH, selector="//*[starts-with(@name, '{filename} (conflicted copy')]")
     SYNCED_ACTIVITY_STATUS = SimpleNamespace(by=By.NAME, selector=None)
 
     @staticmethod
@@ -57,12 +58,17 @@ class Activity:
         app().find_element(Activity.SUBTAB_CONTAINER.by, selector).click()
 
     @staticmethod
-    def check_file_exist(filename):
-        squish.waitForObjectExists(
-            Activity.get_not_synced_file_selector(
-                RegularExpression(build_conflicted_regex(filename))
-            )
+    def has_conflict_file(filename):
+        filename = filename.rsplit(".", 1)[0]
+        has_activity = wait_for(
+            lambda: app().find_element(
+                Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.by,
+                Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.selector.format(filename=filename)
+            ).is_displayed(),
+            get_config('max_timeout')
         )
+        if not has_activity:
+            raise AssertionError(f"File conflict activity not found")
 
     @staticmethod
     def is_resource_blacklisted(filename):

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -13,7 +13,7 @@ class SyncConnection:
     )
     FOLDER_SYNC_CONNECTION_MENU_BUTTON = SimpleNamespace(
         by=By.NAME,
-        selector="{sync_folder},Success,Local folder: {sync_path}{sync_folder}",
+        selector="{sync_folder},{status},Local folder: {sync_path}{sync_folder}",
     )
     MENU_ITEM = SimpleNamespace(by=By.NAME, selector=None)
     SELECTIVE_SYNC_APPLY_BUTTON = SimpleNamespace(by=None, selector=None)
@@ -38,23 +38,33 @@ class SyncConnection:
         return None
 
     @staticmethod
-    def open_menu(sync_folder=None):
+    def open_menu(sync_folder=None, sync_state="success"):
         if sync_folder is None:
             sync_folder = get_config('syncConnectionName')
+
+        if sync_state == "success":
+            status = "Success"
+        elif sync_state == "paused":
+            status = "Sync paused"
+        elif sync_state == "queued":
+            status = "Queued"
+        else:
+            raise ValueError(f"Unknown sync_state: {sync_state}")
 
         connection = SyncConnection.get_current_account_connection()
         menu_button = connection.find_element(
             SyncConnection.FOLDER_SYNC_CONNECTION_MENU_BUTTON.by,
             SyncConnection.FOLDER_SYNC_CONNECTION_MENU_BUTTON.selector.format(
                 sync_folder=sync_folder,
-                sync_path=get_config('currentUserSyncPath'),
+                sync_path=get_config("currentUserSyncPath"),
+                status=status,
             ),
         )
         menu_button.native_click(button='right')
 
     @staticmethod
-    def perform_action(action):
-        SyncConnection.open_menu()
+    def perform_action(action, sync_state="success"):
+        SyncConnection.open_menu(sync_state=sync_state)
         app().find_element(SyncConnection.MENU_ITEM.by, action).click()
 
     @staticmethod
@@ -67,7 +77,7 @@ class SyncConnection:
 
     @staticmethod
     def resume_sync():
-        SyncConnection.perform_action("Resume sync")
+        SyncConnection.perform_action("Resume sync", "paused")
 
     @staticmethod
     def has_menu_item(item):
@@ -93,6 +103,7 @@ class SyncConnection:
                 SyncConnection.FOLDER_SYNC_CONNECTION_MENU_BUTTON.selector.format(
                     sync_folder=sync_folder,
                     sync_path=get_config('currentUserSyncPath'),
+                    status="success"
                 ),
             )
             return True

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -239,17 +239,17 @@ def step(context, resource_type, resource):
         exists(resource_path).should.be.false
 
 
-@Given('the user has changed the content of local file "|any|" to:')
+@Given('the user has changed the content of local file "{filename}" to:')
 def step(context, filename):
-    file_content = '\n'.join(context.multiLineText)
+    file_content = context.text
     wait_and_write_file(get_resource_path(filename), file_content)
 
 
 @Then(
-    'a conflict file for "|any|" should exist on the file system with the following content'
+    'a conflict file for "{filename}" should exist on the file system with the following content'
 )
 def step(context, filename):
-    expected = '\n'.join(context.multiLineText)
+    expected = context.text
 
     onlyfiles = [
         f for f in os.listdir(get_resource_path()) if isfile(get_resource_path(f))

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -1,4 +1,5 @@
-from behave import when as When, then as Then
+import time
+from behave import when as When, then as Then, given as Given
 from sure import ensure
 
 from pageObjects.SyncConnectionWizard import SyncConnectionWizard
@@ -108,9 +109,9 @@ def step(context):
     Toolbar.open_settings_tab()
 
 
-@Then('the table of conflict warnings should include file "|any|"')
+@Then('the table of conflict warnings should include file "{filename}"')
 def step(context, filename):
-    Activity.check_file_exist(filename)
+    Activity.has_conflict_file(filename)
 
 
 @Then('the {resource_type:ResourceType} "{resourceName}" should be blacklisted')
@@ -348,9 +349,9 @@ def step(context):
         expected_error_message.should.equal(actual_error_message)
 
 
-@Given('the user has waited for "|any|" seconds')
+@Given('the user has waited for "{wait_for}" seconds')
 def step(context, wait_for):
-    squish.snooze(float(wait_for))
+    time.sleep(float(wait_for))
 
 
 @When(


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861

This PR was opened to fix the following test scenario:

```feature
Scenario: Syncing a file from the server and creating a conflict
```

But there happens to be an existing [issue](https://github.com/opencloud-eu/desktop/issues/649) regarding the `Not synced` activity and that's the reason for the flakiness of this conflict generation test. So, for now the test scenario is still skipped.

But the remaining changes from this PR will be needed in other PRs, so keeping it.