### PR TITLE
test(gui): port spaces test to appium

### DIFF
--- a/test/gui/features/spaces/spaces.feature
+++ b/test/gui/features/spaces/spaces.feature
@@ -16,7 +16,7 @@ Feature: Project spaces
         Then user "Alice" should be able to open the file "testfile.txt" on the file system
         And as "Alice" the file "testfile.txt" should have content "some content" on the file system
 
-    @skip
+
     Scenario: User with Viewer role cannot edit the file
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
@@ -68,7 +68,7 @@ Feature: Project spaces
         Then for user "Alice" sync folder "Project101" should not be displayed
         But the file "testfile.txt" should exist on the file system
 
-    @skip
+
     Scenario: User with Viewer role cannot create resource
         Given the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with space "Project101"

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -13,7 +13,8 @@ from helpers.Utils import wait_for
 class Activity:
     TAB_CONTAINER = SimpleNamespace(by=None, selector=None)
     SUBTAB_CONTAINER = SimpleNamespace(
-        by=By.CLASS_NAME, selector="[page tab | {tab_name}]"
+        by=By.XPATH,
+        selector="//page_tab[starts-with(@name, '{tab_name}')]"
     )
     NOT_SYNCED_TABLE = SimpleNamespace(by=None, selector=None)
     LOCAL_ACTIVITY_FILTER_BUTTON = SimpleNamespace(by=By.NAME, selector="Filter")
@@ -30,6 +31,7 @@ class Activity:
     SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     NOT_SYNCED_ACTIVITY_TABLE_HEADER_SELECTOR = SimpleNamespace(by=None, selector=None)
     SYNCED_ACTIVITY_STATUS = SimpleNamespace(by=By.NAME, selector=None)
+
 
     @staticmethod
     def get_not_synced_file_selector(resource):
@@ -52,7 +54,7 @@ class Activity:
         ).text
 
     @staticmethod
-    def click_tab(tab_name):
+    def open_tab(tab_name):
         selector = Activity.SUBTAB_CONTAINER.selector.format(tab_name=tab_name)
         app().find_element(Activity.SUBTAB_CONTAINER.by, selector).click()
 

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import NoSuchElementException
 
 from helpers.ConfigHelper import get_config
 from helpers.AppHelper import app
+from helpers.Utils import wait_for
 
 
 class SyncConnection:
@@ -20,7 +21,10 @@ class SyncConnection:
     CONFIRM_FOLDER_SYNC_CONNECTION_REMOVE = SimpleNamespace(
         by=By.NAME, selector="Remove Space"
     )
-    PERMISSION_ERROR_LABEL = SimpleNamespace(by=None, selector=None)
+    PERMISSION_ERROR_LABEL = SimpleNamespace(
+        by=By.XPATH,
+        selector="//label[contains(@name, 'permission')]"
+    )
 
     @staticmethod
     def get_current_account_connection():
@@ -116,8 +120,12 @@ class SyncConnection:
     @staticmethod
     def wait_for_error_label(to_exist=True):
         """Wait for permission error label to appear or disappear"""
-        status = squish.waitFor(
-            lambda: object.exists(SyncConnection.PERMISSION_ERROR_LABEL) == to_exist,
+
+        status = wait_for(
+            lambda: (bool(app().find_elements(
+                SyncConnection.PERMISSION_ERROR_LABEL.by,
+                SyncConnection.PERMISSION_ERROR_LABEL.selector
+            ))) == to_exist,
             get_config("max_timeout"),
         )
         if not status:
@@ -128,4 +136,9 @@ class SyncConnection:
     def get_permission_error_message():
         """Get the permission error message text"""
         SyncConnection.wait_for_error_label(True)  # Wait for label to appear
-        return str(squish.waitForObject(SyncConnection.PERMISSION_ERROR_LABEL).text)
+        element = app().find_element(
+            SyncConnection.PERMISSION_ERROR_LABEL.by,
+            SyncConnection.PERMISSION_ERROR_LABEL.selector
+        )
+        return str(element.text)
+

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -379,10 +379,11 @@ def step(context, user, file_name, content):
         content.should.equal(file_content)
 
 
-@Then('user "|any|" should not be able to edit the file "|any|" on the file system')
+@Then('user "{user}" should not be able to edit the file "{file_name}" on the file system')
 def step(context, user, file_name):
     file_path = get_resource_path(file_name, user)
-    test.compare(not can_write(file_path), True, 'File should not be writable')
+    with ensure('File should not be writable, but it is'):
+        can_write(file_path).should.be.false
 
 
 @Given(

--- a/test/gui/steps/spaces_context.py
+++ b/test/gui/steps/spaces_context.py
@@ -1,4 +1,5 @@
 from sure import ensure
+from behave import given as Given
 
 from pageObjects.EnterPassword import EnterPassword
 from pageObjects.Toolbar import Toolbar

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -132,7 +132,7 @@ def step(context, filename):
 
 @When('the user selects "{tab_name}" tab in the activity')
 def step(context, tab_name):
-    Activity.click_tab(tab_name)
+    Activity.open_tab(tab_name)
 
 
 @Then('the toolbar should have the following tabs:')
@@ -334,18 +334,15 @@ def step(context, filter_option):
 
 @Then('the following error message should appear in the client')
 def step(context):
-    expected_error_message = '\n'.join(context.multiLineText)
+    expected_error_message = context.text
 
     actual_error_message = SyncConnection.get_permission_error_message()
 
     # wait for error message to disappear
     SyncConnection.wait_for_error_label(False)
 
-    test.compare(
-        actual_error_message,
-        expected_error_message,
-        f'Expected error message: "{expected_error_message}" but got: "{actual_error_message}"',
-    )
+    with ensure(f'Expected error message: "{expected_error_message}" but got: "{actual_error_message}"'):
+        expected_error_message.should.equal(actual_error_message)
 
 
 @Given('the user has waited for "|any|" seconds')


### PR DESCRIPTION
Part of: https://github.com/opencloud-eu/desktop/issues/861

This PR enables the following spaces test:
```feature
    Scenario: User with Viewer role cannot edit the file
```
```feature
    Scenario: User with Viewer role cannot create resource
```


Note: The step definition for the activity tab selection step (And the user selects "Not Synced" tab in the activity) was updated as part of the changes introduced in PR https://github.com/opencloud-eu/desktop/pull/932.
