### PR TITLE
Add opt-in text conflict automerge

### DIFF
--- a/cmake/modules/FindLibGit2.cmake
+++ b/cmake/modules/FindLibGit2.cmake
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_LibGit2 QUIET libgit2)
+
+find_path(LibGit2_INCLUDE_DIR
+    NAMES git2.h
+    HINTS ${PC_LibGit2_INCLUDE_DIRS}
+)
+
+find_library(LibGit2_LIBRARY
+    NAMES git2 libgit2
+    HINTS ${PC_LibGit2_LIBRARY_DIRS}
+)
+
+if(LibGit2_INCLUDE_DIR)
+    file(STRINGS "${LibGit2_INCLUDE_DIR}/git2/version.h" _libgit2_version_line
+        REGEX "#define LIBGIT2_VERSION \"[^\"]+\""
+    )
+    string(REGEX REPLACE ".*\"([^\"]+)\".*" "\\1" LibGit2_VERSION "${_libgit2_version_line}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibGit2
+    REQUIRED_VARS LibGit2_LIBRARY LibGit2_INCLUDE_DIR
+    VERSION_VAR LibGit2_VERSION
+)
+
+if(LibGit2_FOUND AND NOT TARGET LibGit2::LibGit2)
+    add_library(LibGit2::LibGit2 UNKNOWN IMPORTED)
+    set_target_properties(LibGit2::LibGit2 PROPERTIES
+        IMPORTED_LOCATION "${LibGit2_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LibGit2_INCLUDE_DIR}"
+    )
+endif()
+
+mark_as_advanced(LibGit2_INCLUDE_DIR LibGit2_LIBRARY)

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -67,6 +67,10 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         ConfigFile().setMoveToTrash(checked);
         Q_EMIT syncOptionsChanged();
     });
+    connect(_ui->autoMergeTextConflictsCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+        ConfigFile().setAutoMergeTextConflicts(checked);
+        Q_EMIT syncOptionsChanged();
+    });
 
     connect(_ui->ignoredFilesButton, &QAbstractButton::clicked, this, &GeneralSettings::slotIgnoreFilesEditor);
     connect(_ui->logSettingsButton, &QPushButton::clicked, this, [] {
@@ -136,6 +140,7 @@ void GeneralSettings::reloadConfig()
 {
     _ui->syncHiddenFilesCheckBox->setChecked(!FolderMan::instance()->ignoreHiddenFiles());
     _ui->moveToTrashCheckBox->setChecked(ConfigFile().moveToTrash());
+    _ui->autoMergeTextConflictsCheckBox->setChecked(ConfigFile().autoMergeTextConflicts());
     if (Utility::isWindows() && Utility::isInstalledByStore()) {
         _ui->autostartCheckBox->setVisible(false);
     } else {

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -120,6 +120,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="autoMergeTextConflictsCheckBox">
+              <property name="text">
+               <string>Automatically merge text file conflicts when possible</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="horizontalLayout_4">
               <item>
                <widget class="QPushButton" name="ignoredFilesButton">
@@ -242,6 +249,7 @@
   <tabstop>syncHiddenFilesCheckBox</tabstop>
   <tabstop>crashreporterCheckBox</tabstop>
   <tabstop>moveToTrashCheckBox</tabstop>
+  <tabstop>autoMergeTextConflictsCheckBox</tabstop>
   <tabstop>ignoredFilesButton</tabstop>
   <tabstop>logSettingsButton</tabstop>
   <tabstop>widget</tabstop>

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -1,7 +1,13 @@
 find_package(LibreGraphAPI 1.0.4 REQUIRED)
+find_package(LibGit2 REQUIRED)
 set_package_properties(LibreGraphAPI PROPERTIES
         URL https://github.com/owncloud/libre-graph-api-cpp-qt-client.git
         DESCRIPTION "Libre Graph is a free API for cloud collaboration inspired by the MS Graph API"
+        TYPE REQUIRED
+)
+set_package_properties(LibGit2 PROPERTIES
+        URL https://libgit2.org
+        DESCRIPTION "Portable Git library used for three-way text conflict automerge"
         TYPE REQUIRED
 )
 
@@ -23,6 +29,7 @@ add_library(libsync SHARED
     logger.cpp
     accessmanager.cpp
     configfile.cpp
+    conflictautomerge.cpp
     globalconfig.cpp
     abstractnetworkjob.cpp
     networkjobs.cpp
@@ -101,6 +108,7 @@ target_link_libraries(libsync
     PRIVATE
         Qt::Concurrent
         ZLIB::ZLIB
+        LibGit2::LibGit2
         Qt6Keychain::Qt6Keychain
         SQLite::SQLite3
 )

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -87,6 +87,7 @@ const QString pauseSyncWhenMeteredC()
     return QStringLiteral("pauseWhenMetered");
 }
 const QString moveToTrashC() { return QStringLiteral("moveToTrash"); }
+const QString autoMergeTextConflictsC() { return QStringLiteral("autoMergeTextConflicts"); }
 
 const QString issuesWidgetFilterC()
 {
@@ -430,6 +431,16 @@ bool ConfigFile::moveToTrash() const
 void ConfigFile::setMoveToTrash(bool isChecked)
 {
     setValue(moveToTrashC(), isChecked);
+}
+
+bool ConfigFile::autoMergeTextConflicts() const
+{
+    return getValue(autoMergeTextConflictsC(), false).toBool();
+}
+
+void ConfigFile::setAutoMergeTextConflicts(bool isChecked)
+{
+    setValue(autoMergeTextConflictsC(), isChecked);
 }
 
 bool ConfigFile::crashReporter() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -115,6 +115,10 @@ public:
     bool moveToTrash() const;
     void setMoveToTrash(bool);
 
+    /** Whether text file conflicts should be automatically merged when possible. */
+    bool autoMergeTextConflicts() const;
+    void setAutoMergeTextConflicts(bool);
+
     /// Used for testing, so we do not change the user's config file.
     static bool setConfDir(const QString &value);
 

--- a/src/libsync/conflictautomerge.cpp
+++ b/src/libsync/conflictautomerge.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) by OpenCloud GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "libsync/conflictautomerge.h"
+
+#include "libsync/account.h"
+#include "libsync/configfile.h"
+#include "libsync/filesystem.h"
+
+#include "common/utility.h"
+
+#include <QDateTime>
+#include <QBuffer>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QMimeDatabase>
+#include <QNetworkRequest>
+#include <QXmlStreamReader>
+
+#include <git2.h>
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcConflictAutoMerge, "sync.conflictautomerge", QtInfoMsg)
+
+namespace {
+constexpr qint64 MaxAutoMergeFileSize = 1024 * 1024;
+
+QString versionNameFromHref(const QString &href)
+{
+    const auto path = href.endsWith(QLatin1Char('/')) ? href.left(href.size() - 1) : href;
+    const auto slash = path.lastIndexOf(QLatin1Char('/'));
+    return slash >= 0 ? path.mid(slash + 1) : path;
+}
+
+QByteArray readAll(const QString &fileName, QIODevice::OpenMode mode = {})
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly | mode)) {
+        return {};
+    }
+    return file.readAll();
+}
+
+bool writeAll(const QString &fileName, const QByteArray &data, QIODevice::OpenMode mode = {})
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | mode)) {
+        return false;
+    }
+    return file.write(data) == data.size();
+}
+
+bool containsNulByte(const QByteArray &data)
+{
+    return data.contains('\0');
+}
+
+bool mergeFiles(const QString &baseFileName, const QString &localFileName, const QString &remoteFileName, const QString &mergedFileName)
+{
+    const auto base = readAll(baseFileName, QIODevice::Text);
+    const auto local = readAll(localFileName, QIODevice::Text);
+    const auto remote = readAll(remoteFileName, QIODevice::Text);
+    if (base.isEmpty() && QFileInfo(baseFileName).size() > 0) {
+        return false;
+    }
+    if (local.isEmpty() && QFileInfo(localFileName).size() > 0) {
+        return false;
+    }
+    if (remote.isEmpty() && QFileInfo(remoteFileName).size() > 0) {
+        return false;
+    }
+
+    git_libgit2_init();
+
+    git_merge_file_input ancestor = GIT_MERGE_FILE_INPUT_INIT;
+    ancestor.ptr = base.constData();
+    ancestor.size = static_cast<size_t>(base.size());
+    ancestor.path = "base";
+
+    git_merge_file_input ours = GIT_MERGE_FILE_INPUT_INIT;
+    ours.ptr = local.constData();
+    ours.size = static_cast<size_t>(local.size());
+    ours.path = "local";
+
+    git_merge_file_input theirs = GIT_MERGE_FILE_INPUT_INIT;
+    theirs.ptr = remote.constData();
+    theirs.size = static_cast<size_t>(remote.size());
+    theirs.path = "remote";
+
+    git_merge_file_options options = GIT_MERGE_FILE_OPTIONS_INIT;
+    options.favor = GIT_MERGE_FILE_FAVOR_NORMAL;
+    options.flags = GIT_MERGE_FILE_STYLE_MERGE;
+
+    git_merge_file_result result = {};
+    const int rc = git_merge_file(&result, &ancestor, &ours, &theirs, &options);
+    const bool hasResult = result.ptr || result.len == 0;
+    const bool merged = rc == 0 && result.automergeable && hasResult
+        && writeAll(mergedFileName, QByteArray(result.ptr, static_cast<qsizetype>(result.len)), QIODevice::Text);
+    if (!merged) {
+        qCInfo(lcConflictAutoMerge) << "libgit2 merge failed"
+                                    << "rc" << rc
+                                    << "automergeable" << result.automergeable
+                                    << "hasResult" << hasResult;
+    }
+    git_merge_file_result_free(&result);
+    git_libgit2_shutdown();
+    return merged;
+}
+
+SyncJournalFileRecord baseRecordFor(OwncloudPropagator *propagator, const SyncFileItemPtr &item)
+{
+    auto baseRecord = propagator->_journal->getFileRecord(item->_originalFile);
+    if (!baseRecord.isValid() && item->_originalFile != item->localName()) {
+        baseRecord = propagator->_journal->getFileRecord(item->localName());
+    }
+    return baseRecord;
+}
+}
+
+ConflictAutoMerge::ConflictAutoMerge(OwncloudPropagator *propagator, const SyncFileItemPtr &item, const QString &localFile, const QString &remoteFile,
+    QObject *parent)
+    : QObject(parent)
+    , _propagator(propagator)
+    , _item(item)
+    , _localFile(localFile)
+    , _remoteFile(remoteFile)
+    , _baseRecord(baseRecordFor(propagator, item))
+{
+}
+
+bool ConflictAutoMerge::canStart() const
+{
+    const auto enabled = ConfigFile().autoMergeTextConflicts();
+    const auto conflict = _item->instruction() == CSYNC_INSTRUCTION_CONFLICT;
+    const auto file = !_item->isDirectory();
+    const auto versioning = _propagator->account()->capabilities().versioningEnabled();
+    const auto baseValid = _baseRecord.isValid();
+    const auto hasBaseFileId = !_baseRecord.fileId().isEmpty();
+    const auto hasBaseEtag = !_baseRecord.etag().isEmpty();
+    const auto localText = isTextMergeCandidate(_localFile);
+    const auto remoteText = isTextMergeCandidate(_remoteFile);
+
+    const auto canStart = enabled && conflict && file && versioning && baseValid && hasBaseFileId && hasBaseEtag && localText && remoteText;
+    if (conflict && !canStart) {
+        qCInfo(lcConflictAutoMerge) << "Text conflict automerge not started"
+                                    << _item->localName()
+                                    << "enabled" << enabled
+                                    << "file" << file
+                                    << "versioning" << versioning
+                                    << "baseValid" << baseValid
+                                    << "hasBaseFileId" << hasBaseFileId
+                                    << "hasBaseEtag" << hasBaseEtag
+                                    << "localText" << localText
+                                    << "remoteText" << remoteText
+                                    << "originalFile" << _item->_originalFile
+                                    << "localFile" << _localFile
+                                    << "remoteFile" << _remoteFile
+                                    << "basePath" << _baseRecord.path();
+    }
+    return canStart;
+}
+
+void ConflictAutoMerge::start()
+{
+    if (!canStart()) {
+        emitNotMerged();
+        return;
+    }
+
+    QNetworkRequest request;
+    request.setRawHeader("Depth", "1");
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("text/xml; charset=utf-8"));
+
+    QByteArray body = QByteArrayLiteral(
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        "<d:propfind xmlns:d=\"DAV:\"><d:prop><d:getetag/><d:getlastmodified/><d:getcontentlength/></d:prop></d:propfind>\n");
+    _versionsJob = new SimpleNetworkJob(_propagator->account(), _propagator->account()->url(),
+        QStringLiteral("dav/meta/%1/v/").arg(QString::fromUtf8(_baseRecord.fileId())), QByteArrayLiteral("PROPFIND"), std::move(body), request, this);
+
+    connect(_versionsJob, &SimpleNetworkJob::finishedSignal, this, [this] {
+        if (!_versionsJob || _versionsJob->reply()->error() != QNetworkReply::NoError || _versionsJob->httpStatusCode() / 100 != 2) {
+            qCInfo(lcConflictAutoMerge) << "Could not list base versions" << _item->localName() << _versionsJob->errorString();
+            emitNotMerged();
+            return;
+        }
+
+        const auto xml = _versionsJob->reply()->readAll();
+        QXmlStreamReader reader(xml);
+        VersionInfo version;
+        bool inResponse = false;
+        while (!reader.atEnd()) {
+            reader.readNext();
+            if (reader.isStartElement() && reader.name() == QLatin1String("response")) {
+                version = {};
+                inResponse = true;
+            } else if (reader.isEndElement() && reader.name() == QLatin1String("response")) {
+                if (!version.name.isEmpty()) {
+                    _versions.append(version);
+                }
+                inResponse = false;
+            } else if (inResponse && reader.isStartElement() && reader.name() == QLatin1String("href")) {
+                const auto href = reader.readElementText();
+                if (href.contains(QLatin1String("/v/"))) {
+                    version.name = versionNameFromHref(href);
+                }
+            } else if (inResponse && reader.isStartElement() && reader.name() == QLatin1String("getetag")) {
+                version.etag = Utility::normalizeEtag(reader.readElementText());
+            } else if (inResponse && reader.isStartElement() && reader.name() == QLatin1String("getlastmodified")) {
+                const auto lastModified = reader.readElementText();
+                if (!lastModified.isEmpty()) {
+                    version.mtime = Utility::qDateTimeToTime_t(Utility::parseRFC1123Date(lastModified));
+                }
+            }
+        }
+        if (reader.hasError()) {
+            qCInfo(lcConflictAutoMerge) << "Could not parse base versions" << _item->localName() << reader.errorString();
+            emitNotMerged();
+            return;
+        }
+        versionsListed();
+    });
+    _versionsJob->start();
+}
+
+bool ConflictAutoMerge::isTextMergeCandidate(const QString &fileName) const
+{
+    const QFileInfo info(fileName);
+    if (!info.isFile() || info.size() > MaxAutoMergeFileSize) {
+        return false;
+    }
+    if (info.size() == 0) {
+        return true;
+    }
+
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+    const auto data = file.read(MaxAutoMergeFileSize + 1);
+    if (data.size() > MaxAutoMergeFileSize || containsNulByte(data)) {
+        return false;
+    }
+
+    QMimeDatabase mimeDb;
+    QBuffer buffer;
+    buffer.setData(data);
+    buffer.open(QIODevice::ReadOnly);
+    const auto mimeType = mimeDb.mimeTypeForFileNameAndData(fileName, &buffer);
+    return mimeType.inherits(QStringLiteral("text/plain"))
+        || mimeType.name().startsWith(QStringLiteral("text/"))
+        || mimeType.name() == QLatin1String("application/json")
+        || mimeType.name() == QLatin1String("application/xml")
+        || mimeType.name() == QLatin1String("application/x-yaml")
+        || mimeType.name() == QLatin1String("application/javascript");
+}
+
+void ConflictAutoMerge::versionsListed()
+{
+    const auto versionName = matchingVersionName();
+    if (versionName.isEmpty()) {
+        qCInfo(lcConflictAutoMerge) << u"No matching base version for" << _item->localName();
+        emitNotMerged();
+        return;
+    }
+
+    _baseJob = new SimpleNetworkJob(_propagator->account(), _propagator->account()->url(),
+        QStringLiteral("dav/meta/%1/v/%2").arg(QString::fromUtf8(_baseRecord.fileId()), versionName), QByteArrayLiteral("GET"), this);
+    connect(_baseJob, &SimpleNetworkJob::finishedSignal, this, &ConflictAutoMerge::baseDownloaded);
+    _baseJob->start();
+}
+
+void ConflictAutoMerge::baseDownloaded()
+{
+    if (!_baseJob || _baseJob->reply()->error() != QNetworkReply::NoError || _baseJob->httpStatusCode() / 100 != 2) {
+        emitNotMerged();
+        return;
+    }
+
+    const auto baseData = _baseJob->reply()->readAll();
+    if (baseData.size() > MaxAutoMergeFileSize || containsNulByte(baseData) || !_baseFile.open()) {
+        qCInfo(lcConflictAutoMerge) << "Downloaded base version is not mergeable" << _item->localName();
+        emitNotMerged();
+        return;
+    }
+    if (_baseFile.write(baseData) != baseData.size()) {
+        qCInfo(lcConflictAutoMerge) << "Could not write base version for automerge" << _item->localName();
+        emitNotMerged();
+        return;
+    }
+    _baseFile.close();
+
+    runMerge();
+}
+
+void ConflictAutoMerge::emitNotMerged()
+{
+    Q_EMIT finished(false, {});
+}
+
+void ConflictAutoMerge::runMerge()
+{
+    QString mergedFileName;
+    {
+        QTemporaryFile mergedFile(QDir::tempPath() + QStringLiteral("/opencloud-automerge-XXXXXX"));
+        mergedFile.setAutoRemove(false);
+        if (!mergedFile.open()) {
+            emitNotMerged();
+            return;
+        }
+        mergedFileName = mergedFile.fileName();
+        mergedFile.close();
+    }
+
+    if (!mergeFiles(_baseFile.fileName(), _localFile, _remoteFile, mergedFileName)) {
+        qCInfo(lcConflictAutoMerge) << "Could not automatically merge text conflict" << _item->localName();
+        QFile::remove(mergedFileName);
+        emitNotMerged();
+        return;
+    }
+
+    qCInfo(lcConflictAutoMerge) << u"Automatically merged text conflict" << _item->localName();
+    Q_EMIT finished(true, mergedFileName);
+}
+
+QString ConflictAutoMerge::matchingVersionName() const
+{
+    const auto baseEtag = Utility::normalizeEtag(_baseRecord.etag());
+    for (const auto &version : _versions) {
+        if (!version.etag.isEmpty() && version.etag == baseEtag) {
+            return version.name;
+        }
+    }
+
+    if (_baseRecord.modtime() <= 0) {
+        return {};
+    }
+    for (const auto &version : _versions) {
+        if (version.mtime == _baseRecord.modtime()) {
+            return version.name;
+        }
+    }
+
+    return {};
+}
+
+}

--- a/src/libsync/conflictautomerge.h
+++ b/src/libsync/conflictautomerge.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) by OpenCloud GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "libsync/networkjobs.h"
+#include "libsync/networkjobs/simplenetworkjob.h"
+#include "libsync/owncloudpropagator.h"
+#include "libsync/common/syncjournalfilerecord.h"
+
+#include <QPointer>
+#include <QList>
+#include <QString>
+#include <QTemporaryFile>
+
+#include <ctime>
+
+namespace OCC {
+
+class ConflictAutoMerge : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ConflictAutoMerge(OwncloudPropagator *propagator, const SyncFileItemPtr &item, const QString &localFile, const QString &remoteFile,
+        QObject *parent = nullptr);
+
+    bool canStart() const;
+    void start();
+
+Q_SIGNALS:
+    void finished(bool merged, const QString &mergedFileName);
+
+private:
+    struct VersionInfo
+    {
+        QString name;
+        QString etag;
+        time_t mtime = 0;
+    };
+
+    bool isTextMergeCandidate(const QString &fileName) const;
+    void versionsListed();
+    void baseDownloaded();
+    void emitNotMerged();
+    void runMerge();
+    QString matchingVersionName() const;
+
+    OwncloudPropagator *_propagator = nullptr;
+    SyncFileItemPtr _item;
+    QString _localFile;
+    QString _remoteFile;
+    SyncJournalFileRecord _baseRecord;
+    QList<VersionInfo> _versions;
+    QPointer<SimpleNetworkJob> _versionsJob;
+    QPointer<SimpleNetworkJob> _baseJob;
+    QTemporaryFile _baseFile;
+};
+
+}

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -464,7 +464,8 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(
             }
             // NOTE: This prohibits some VFS renames from being detected since
             // suffix-file size is different from the db size. That's ok, they'll DELETE+NEW.
-            if (FileSystem::fileTimeToTime_t(info.last_write_time()) != base.modtime() || info.file_size() != base.size() || info.is_directory()) {
+            if (!FileSystem::modTimeEquals(FileSystem::fileTimeToTime_t(info.last_write_time()), base.modtime())
+                || info.file_size() != static_cast<uintmax_t>(base.size()) || info.is_directory()) {
                 qCInfo(lcDisco) << u"The file has changed locally, not a rename." << originalPath;
                 return;
             }
@@ -632,7 +633,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
                 item->setInstruction(CSYNC_INSTRUCTION_REMOVE);
                 item->_direction = SyncFileItem::Down;
             }
-        } else if (!typeChange && ((dbEntry.modtime() == localEntry.modtime() && dbEntry.size() == localEntry.size()) || localEntry.isDirectory())) {
+        } else if (!typeChange && ((FileSystem::modTimeEquals(dbEntry.modtime(), localEntry.modtime()) && dbEntry.size() == localEntry.size()) || localEntry.isDirectory())) {
             // Local file unchanged.
             if (noServerEntry) {
                 item->setInstruction(CSYNC_INSTRUCTION_REMOVE);
@@ -745,9 +746,9 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             return false;
         }
         // Directories and virtual files don't need size/mtime equality
-        if (!localEntry.isDirectory() && !base.isVirtualFile() && (base.modtime() != localEntry.modtime() || base.size() != localEntry.size())) {
+        if (!localEntry.isDirectory() && !base.isVirtualFile() && (!FileSystem::modTimeEquals(base.modtime(), localEntry.modtime()) || base.size() != localEntry.size())) {
             qCInfo(lcDisco) << u"Not a move, mtime or size differs, " << u"modtime:" << base.modtime() << localEntry.modtime() << u", " << u"size:"
-                            << base.size() << localEntry.size();
+                             << base.size() << localEntry.size();
             return false;
         }
 
@@ -900,7 +901,7 @@ void ProcessDirectoryJob::processFileConflict(const SyncFileItemPtr &item, const
     if (serverEntry.checksumHeader().isEmpty()) {
         // If the size or mtime is different, it's definitely a conflict.
         bool sizeDiffers = serverEntry.size() != localEntry.size();
-        bool modTimeDiffers = serverEntry.modtime() != localEntry.modtime();
+        bool modTimeDiffers = !FileSystem::modTimeEquals(serverEntry.modtime(), localEntry.modtime());
         bool isConflict = sizeDiffers || modTimeDiffers;
         if (isConflict) {
             qCDebug(lcDisco) << serverEntry.name() << u": detected conflict: size difference: " << sizeDiffers << u"mtime difference: " << modTimeDiffers;
@@ -931,14 +932,14 @@ void ProcessDirectoryJob::processFileConflict(const SyncFileItemPtr &item, const
     auto up = _discoveryData->_statedb->getUploadInfo(path._original);
     if (up._valid && up._contentChecksum == serverEntry.checksumHeader()) {
         // Solve the conflict into an upload, or update meta data
-        item->setInstruction(up._modtime == localEntry.modtime() && up._size == localEntry.size() ? CSYNC_INSTRUCTION_UPDATE_METADATA : CSYNC_INSTRUCTION_SYNC);
+        item->setInstruction(FileSystem::modTimeEquals(up._modtime, localEntry.modtime()) && up._size == localEntry.size() ? CSYNC_INSTRUCTION_UPDATE_METADATA : CSYNC_INSTRUCTION_SYNC);
         item->_direction = SyncFileItem::Up;
 
         if (item->instruction() == CSYNC_INSTRUCTION_UPDATE_METADATA) {
             // Update the etag and other server metadata in the journal already
             Q_ASSERT(item->localName() == path._original);
             Q_ASSERT(item->_size == serverEntry.size());
-            Q_ASSERT(item->_modtime == serverEntry.modtime());
+            Q_ASSERT(FileSystem::modTimeEquals(item->_modtime, serverEntry.modtime()));
             Q_ASSERT(!serverEntry.etag().isEmpty());
             item->_etag = serverEntry.etag();
             item->_fileId = serverEntry.fileId();
@@ -1008,7 +1009,8 @@ void ProcessDirectoryJob::processBlacklisted(const PathTuple &path, const OCC::L
     item->_inode = localEntry.inode();
     item->_isSelectiveSync = true;
     if (dbEntry.isValid()
-        && ((dbEntry.modtime() == localEntry.modtime() && dbEntry.size() == localEntry.size()) || (localEntry.isDirectory() && dbEntry.isDirectory()))) {
+        && ((FileSystem::modTimeEquals(dbEntry.modtime(), localEntry.modtime()) && dbEntry.size() == localEntry.size())
+            || (localEntry.isDirectory() && dbEntry.isDirectory()))) {
         item->setInstruction(CSYNC_INSTRUCTION_REMOVE);
         item->_direction = SyncFileItem::Down;
     } else {

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -27,6 +27,8 @@
 #include "csync.h"
 #include "syncfileitem.h"
 
+#include <chrono>
+#include <cstdlib>
 #include <sys/stat.h>
 
 #ifdef Q_OS_WIN32
@@ -73,6 +75,9 @@ time_t FileSystem::fileTimeToTime_t(std::filesystem::file_time_type fileTime)
 {
 #ifdef HAS_CLOCK_CAST
     return std::chrono::system_clock::to_time_t(std::chrono::clock_cast<std::chrono::system_clock>(fileTime));
+#elif defined(_MSC_VER)
+    const auto systemTime = std::chrono::utc_clock::to_sys(std::chrono::file_clock::to_utc(fileTime));
+    return std::chrono::system_clock::to_time_t(systemTime);
 #else
     const auto systemTime = std::chrono::time_point_cast<std::chrono::system_clock::duration>(std::chrono::file_clock::to_sys(fileTime));
     return std::chrono::system_clock::to_time_t(systemTime);
@@ -82,9 +87,16 @@ std::filesystem::file_time_type FileSystem::time_tToFileTime(time_t fileTime)
 {
 #ifdef HAS_CLOCK_CAST
     return std::chrono::clock_cast<std::chrono::file_clock>(std::chrono::system_clock::from_time_t(fileTime));
+#elif defined(_MSC_VER)
+    return std::chrono::file_clock::from_utc(std::chrono::utc_clock::from_sys(std::chrono::system_clock::from_time_t(fileTime)));
 #else
     return std::chrono::file_clock::from_sys(std::chrono::system_clock::from_time_t(fileTime));
 #endif
+}
+
+bool FileSystem::modTimeEquals(time_t lhs, time_t rhs)
+{
+    return std::llabs(static_cast<long long>(lhs) - static_cast<long long>(rhs)) <= 1;
 }
 
 time_t FileSystem::getModTime(const std::filesystem::path &filename)
@@ -169,7 +181,7 @@ bool FileSystem::fileChanged(const std::filesystem::path &path, const FileChange
         qCDebug(lcFileSystem) << u"File" << path.native() << u"has changed: size: " << previousInfo.size << u"<->" << info.size();
         return true;
     }
-    if (info.modtime() != previousInfo.mtime) {
+    if (!previousInfo.mtime.has_value() || !modTimeEquals(info.modtime(), previousInfo.mtime.value())) {
         qCDebug(lcFileSystem) << u"File" << path.native() << u"has changed: mtime: " << previousInfo.mtime << u"<->" << info.modtime();
         return true;
     }

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -44,6 +44,7 @@ namespace FileSystem {
 
     OPENCLOUD_SYNC_EXPORT time_t fileTimeToTime_t(std::filesystem::file_time_type fileTime);
     OPENCLOUD_SYNC_EXPORT std::filesystem::file_time_type time_tToFileTime(time_t fileTime);
+    OPENCLOUD_SYNC_EXPORT bool modTimeEquals(time_t lhs, time_t rhs);
     /**
      * @brief Get the mtime for a filepath
      *

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -14,6 +14,7 @@
 
 #include "propagatedownload.h"
 #include "account.h"
+#include "conflictautomerge.h"
 #include "filesystem.h"
 #include "libsync/networkjobs/getfilejob.h"
 #include "networkjobs.h"
@@ -604,6 +605,42 @@ void PropagateDownloadFile::contentChecksumComputed(CheckSums::Algorithm checksu
 {
     _item->_checksumHeader = ChecksumHeader(checksumType, checksum).makeChecksumHeader();
 
+    if (startAutoMerge()) {
+        return;
+    }
+
+    downloadFinished();
+}
+
+bool PropagateDownloadFile::startAutoMerge()
+{
+    auto autoMerge = new ConflictAutoMerge(propagator(), _item, propagator()->fullLocalPath(_item->localName()), _tmpFile.fileName(), this);
+    if (!autoMerge->canStart()) {
+        autoMerge->deleteLater();
+        return false;
+    }
+
+    qCInfo(lcPropagateDownload) << "Starting text conflict automerge" << _item->localName();
+    _autoMergeJob = autoMerge;
+    propagator()->_activeJobList.append(this);
+    connect(autoMerge, &ConflictAutoMerge::finished, this, &PropagateDownloadFile::autoMergeFinished);
+    autoMerge->start();
+    return true;
+}
+
+void PropagateDownloadFile::autoMergeFinished(bool merged, const QString &mergedFileName)
+{
+    propagator()->_activeJobList.removeOne(this);
+    if (_autoMergeJob) {
+        _autoMergeJob->deleteLater();
+        _autoMergeJob.clear();
+    }
+
+    if (merged) {
+        _autoMergeResolved = true;
+        _autoMergedFileName = mergedFileName;
+    }
+
     downloadFinished();
 }
 
@@ -615,6 +652,7 @@ void PropagateDownloadFile::downloadFinished()
     // In case of file name clash, report an error
     // This can happen if another parallel download saved a clashing file.
     if (auto clash = propagator()->localFileNameClash(_item->localName())) {
+        removeAutoMergedFile();
         done(SyncFileItem::NormalError,
             tr("The file »%1« cannot be saved because of a local file name clash with »%2«!")
                 .arg(QDir::toNativeSeparators(_item->localName()), QDir::toNativeSeparators(clash.get())));
@@ -638,16 +676,21 @@ void PropagateDownloadFile::downloadFinished()
         // Make the file a hydrated placeholder if possible
         const auto result = propagator()->updatePlaceholder(*_item, _tmpFile.fileName(), fn);
         if (!result) {
+            removeAutoMergedFile();
             done(SyncFileItem::NormalError, result.error());
             return;
         } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
+            removeAutoMergedFile();
             done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(_item->localName()));
             return;
         }
     }
 
     bool isConflict = _item->instruction() == CSYNC_INSTRUCTION_CONFLICT && (QFileInfo(fn).isDir() || !FileSystem::fileEquals(fn, _tmpFile.fileName()));
-    if (isConflict) {
+    if (isConflict && _autoMergeResolved) {
+        isConflict = false;
+        previousFileExists = false;
+    } else if (isConflict) {
         QString error;
         if (!propagator()->createConflict(_item, _associatedComposite, &error)) {
             done(SyncFileItem::SoftError, error);
@@ -662,6 +705,7 @@ void PropagateDownloadFile::downloadFinished()
         // is necessary to avoid overwriting user changes that happened between
         // the discovery phase and now.
         if (FileSystem::fileChanged(FileSystem::toFilesystemPath(fn), FileSystem::FileChangedInfo::fromSyncFileItemPrevious(_item.data()))) {
+            removeAutoMergedFile();
             propagator()->_anotherSyncNeeded = true;
             done(SyncFileItem::SoftError, tr("The file has changed since discovery"));
             return;
@@ -670,8 +714,17 @@ void PropagateDownloadFile::downloadFinished()
     // If the file is locked, we want to retry this sync when it
     // becomes available again
     if (FileSystem::isFileLocked(fn, FileSystem::LockMode::Exclusive)) {
+        removeAutoMergedFile();
         Q_EMIT propagator()->seenLockedFile(fn, FileSystem::LockMode::Exclusive);
         done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(fn));
+        return;
+    }
+
+    if (_autoMergeResolved) {
+        // Record the downloaded remote metadata, then keep the merged file as a local change for the next sync.
+        _item->_size = FileSystem::getSize(FileSystem::toFilesystemPath(_tmpFile.fileName()));
+        FileSystem::remove(_tmpFile.fileName());
+        updateMetadata(false);
         return;
     }
 
@@ -679,6 +732,7 @@ void PropagateDownloadFile::downloadFinished()
     // The fileChanged() check is done above to generate better error messages.
     if (!FileSystem::uncheckedRenameReplace(_tmpFile.fileName(), fn, &error)) {
         qCWarning(lcPropagateDownload) << u"Rename failed:" << _tmpFile.fileName() << u"=>" << fn << u"with error:" << error;
+        removeAutoMergedFile();
         propagator()->_anotherSyncNeeded = true;
         done(SyncFileItem::SoftError, error);
         return;
@@ -703,14 +757,31 @@ void PropagateDownloadFile::updateMetadata(bool isConflict)
 {
     const auto result = propagator()->updateMetadata(*_item);
     if (!result) {
+        removeAutoMergedFile();
         done(SyncFileItem::FatalError, tr("Error updating metadata: %1").arg(result.error()));
         return;
     } else if (result.get() == Vfs::ConvertToPlaceholderResult::Locked) {
+        removeAutoMergedFile();
         done(SyncFileItem::SoftError, tr("The file »%1« is currently in use").arg(_item->localName()));
         return;
     }
     propagator()->_journal->setDownloadInfo(_item->localName(), SyncJournalDb::DownloadInfo());
     propagator()->_journal->commit(QStringLiteral("download file start2"));
+
+    if (_autoMergeResolved) {
+        const auto fn = propagator()->fullLocalPath(_item->localName());
+        QString error;
+        if (!FileSystem::uncheckedRenameReplace(_autoMergedFileName, fn, &error)) {
+            qCWarning(lcPropagateDownload) << u"Installing automerged file failed:" << _autoMergedFileName << u"=>" << fn << u"with error:" << error;
+            removeAutoMergedFile();
+            propagator()->_anotherSyncNeeded = true;
+            done(SyncFileItem::SoftError, error);
+            return;
+        }
+        _autoMergedFileName.clear();
+        FileSystem::setFileHidden(fn, false);
+        propagator()->_anotherSyncNeeded = true;
+    }
 
     done(isConflict ? SyncFileItem::Conflict : SyncFileItem::Success);
 
@@ -730,6 +801,14 @@ void PropagateDownloadFile::updateMetadata(bool isConflict)
     }
 }
 
+void PropagateDownloadFile::removeAutoMergedFile()
+{
+    if (!_autoMergedFileName.isEmpty()) {
+        QFile::remove(_autoMergedFileName);
+        _autoMergedFileName.clear();
+    }
+}
+
 void PropagateDownloadFile::slotDownloadProgress(qint64 received, qint64)
 {
     if (!_job)
@@ -745,6 +824,12 @@ void PropagateDownloadFile::abort(PropagatorJob::AbortType abortType)
     if (_job) {
         _job->abort();
     }
+    if (_autoMergeJob) {
+        propagator()->_activeJobList.removeOne(this);
+        _autoMergeJob->deleteLater();
+        _autoMergeJob.clear();
+    }
+    removeAutoMergedFile();
     if (abortType == AbortType::Asynchronous) {
         Q_EMIT abortFinished();
     }

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -152,6 +152,11 @@ QString OPENCLOUD_SYNC_EXPORT createDownloadTmpFileName(const QString &previous)
     }
 }
 
+PropagateDownloadFile::~PropagateDownloadFile()
+{
+    removeAutoMergedFile();
+}
+
 void PropagateDownloadFile::start()
 {
     if (propagator()->_abortRequested)

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -22,6 +22,8 @@
 
 namespace OCC {
 
+class ConflictAutoMerge;
+
 /**
  * @brief The PropagateDownloadFile class
  * @ingroup libsync
@@ -108,6 +110,7 @@ private Q_SLOTS:
     void transmissionChecksumValidated(CheckSums::Algorithm checksumType, const QByteArray &checksum);
     /// Called when the download's checksum computation is done
     void contentChecksumComputed(CheckSums::Algorithm checksumType, const QByteArray &checksum);
+    void autoMergeFinished(bool merged, const QString &mergedFileName);
     void downloadFinished();
     /// Called when it's time to update the db metadata
     void updateMetadata(bool isConflict);
@@ -118,12 +121,17 @@ private Q_SLOTS:
 
 private:
     void deleteExistingFolder();
+    bool startAutoMerge();
+    void removeAutoMergedFile();
 
     qint64 _resumeStart;
     qint64 _downloadProgress;
     QPointer<GETFileJob> _job;
+    QPointer<ConflictAutoMerge> _autoMergeJob;
     QFile _tmpFile;
     bool _deleteExisting;
+    bool _autoMergeResolved = false;
+    QString _autoMergedFileName;
     ConflictRecord _conflictRecord;
 
     QElapsedTimer _stopwatch;

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -80,6 +80,7 @@ public:
         , _deleteExisting(false)
     {
     }
+    ~PropagateDownloadFile() override;
     void start() override;
     qint64 committedDiskSpace() const override;
 

--- a/translations/desktop_ar.ts
+++ b/translations/desktop_ar.ts
@@ -1283,6 +1283,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>نقل الملفات المحذوفة عن بُعد إلى سلة المهملات المحلية بدلاً من حذفها</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>دمج تعارضات الملفات النصية تلقائيًا عند الإمكان</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>تحرير الملفات المتجاهلة</translation>

--- a/translations/desktop_ca.ts
+++ b/translations/desktop_ca.ts
@@ -1283,6 +1283,11 @@ Si us plau, considereu eliminar aquesta carpeta del compte i afegir-la de nou.</
         <translation>Mou els fitxers eliminats remotament a la paperera local en comptes d’eliminar-los definitivament.</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Fusiona automàticament els conflictes de fitxers de text quan sigui possible</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Edita fitxers ignorats</translation>

--- a/translations/desktop_de.ts
+++ b/translations/desktop_de.ts
@@ -1283,6 +1283,11 @@ Bitte entfernen Sie diesen Ordner aus dem Konto und legen Sie ihn erneut an.</tr
         <translation>Auf anderen Geräten gelöschte Dateien in den lokalen Papierkorb verschieben, anstatt sie zu löschen</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Textdateikonflikte nach Möglichkeit automatisch zusammenführen</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Ignorierte Dateien bearbeiten</translation>

--- a/translations/desktop_el.ts
+++ b/translations/desktop_el.ts
@@ -1283,6 +1283,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>Μετακίνηση των απομακρυσμένα διαγραμμένων αρχείων στον τοπικό κάδο ανακύκλωσης αντί για διαγραφή τους</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Αυτόματη συγχώνευση διενέξεων αρχείων κειμένου όταν είναι δυνατό</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Επεξεργασία αγνοημένων αρχείων</translation>

--- a/translations/desktop_en.ts
+++ b/translations/desktop_en.ts
@@ -1298,6 +1298,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Automatically merge text file conflicts when possible</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation type="unfinished"></translation>

--- a/translations/desktop_fr.ts
+++ b/translations/desktop_fr.ts
@@ -1283,6 +1283,11 @@ Veuillez envisager de supprimer ce dossier du compte et de l&apos;ajouter à nou
         <translation>Déplacer les fichiers distants qui ont été supprimés vers la corbeille locale au lieu de les supprimer définitivement</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Fusionner automatiquement les conflits de fichiers texte lorsque possible</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Modifier les fichiers ignorés</translation>

--- a/translations/desktop_he.ts
+++ b/translations/desktop_he.ts
@@ -1283,6 +1283,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>העברת קבצים שנמחקו מרחוק לסל המיחזור המקומי במקום למחוק אותם</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>מיזוג אוטומטי של התנגשויות בקובצי טקסט כשאפשר</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>עריכת קבצים שמותעלמים מהם</translation>

--- a/translations/desktop_hu.ts
+++ b/translations/desktop_hu.ts
@@ -1283,6 +1283,11 @@ Kérjük vegye fontolóra a mappa eltávolítását a fiókból és újbóli hoz
         <translation>A távolról törölt fájlok áthelyezése a helyi lomtárba törlés helyett</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Szövegfájl-ütközések automatikus egyesítése, amikor lehetséges</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Figyelmen kívül hagyott fájlok szerkesztése</translation>

--- a/translations/desktop_it.ts
+++ b/translations/desktop_it.ts
@@ -1285,6 +1285,11 @@ Si consiglia di rimuovere questa cartella dall&apos;account e di aggiungerla nuo
         <translation>Sposta i file cancellati da remoto nel cestino locale invece di eliminarli.</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Unisci automaticamente i conflitti dei file di testo quando possibile</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Modifica i file ignorati</translation>

--- a/translations/desktop_ja.ts
+++ b/translations/desktop_ja.ts
@@ -1283,6 +1283,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>リモートで削除されたファイルを、直接削除せずローカルのゴミ箱に移動する</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>可能な場合はテキストファイルの競合を自動的にマージする</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>無視するファイルを編集</translation>

--- a/translations/desktop_ko.ts
+++ b/translations/desktop_ko.ts
@@ -1284,6 +1284,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>원격에서 삭제된 파일을 삭제하는 대신 로컬 휴지통으로 이동</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>가능한 경우 텍스트 파일 충돌을 자동으로 병합</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>무시된 파일 편집</translation>

--- a/translations/desktop_lo.ts
+++ b/translations/desktop_lo.ts
@@ -1283,6 +1283,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>ຍ້າຍໄຟລ໌ທີ່ຖືກລຶບຈາກເຊີບເວີໄປໄວ້ໃນຖັງຂີ້ເຫຍື້ອໃນເຄື່ອງ ແທນທີ່ຈະລຶບຖິ້ມທັນທີ</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>ຮວມຂໍ້ຂັດແຍ່ງຂອງໄຟລ໌ຂໍ້ຄວາມໂດຍອັດຕະໂນມັດເມື່ອເປັນໄປໄດ້</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>ແກ້ໄຂລາຍຊື່ໄຟລ໌ທີ່ຖືກລະເວັ້ນ</translation>

--- a/translations/desktop_nl.ts
+++ b/translations/desktop_nl.ts
@@ -1283,6 +1283,11 @@ Overweeg om deze map uit het account te verwijderen en deze opnieuw toe te voege
         <translation>Op afstand verwijderde bestanden naar de lokale prullenbak verplaatsen in plaats van ze te verwijderen</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Tekstbestandsconflicten automatisch samenvoegen wanneer mogelijk</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Genegeerde bestanden bewerken</translation>

--- a/translations/desktop_pl.ts
+++ b/translations/desktop_pl.ts
@@ -1281,6 +1281,11 @@ Rozważ usunięcie tego folderu z konta i dodanie go ponownie.</translation>
         <translation>Przenoś zdalnie usunięte pliki do lokalnego kosza zamiast je usuwać</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Automatycznie scalaj konflikty plików tekstowych, gdy to możliwe</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Edytuj ignorowane pliki</translation>

--- a/translations/desktop_pt.ts
+++ b/translations/desktop_pt.ts
@@ -1283,6 +1283,11 @@ Considere remover esta pasta da conta e adicioná-la novamente.</translation>
         <translation>Mover ficheiros eliminados remotamente para o lixo local em vez de os eliminar</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Unir automaticamente conflitos de ficheiros de texto quando possível</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Editar ficheiros ignorados</translation>

--- a/translations/desktop_ru.ts
+++ b/translations/desktop_ru.ts
@@ -1283,6 +1283,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>Перемещать файлы, удаленные через серверный доступ, в локальную корзину вместо их полного удаления</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Автоматически объединять конфликты текстовых файлов, когда это возможно</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Изменить игнорируемые файлф</translation>

--- a/translations/desktop_sv.ts
+++ b/translations/desktop_sv.ts
@@ -1272,6 +1272,11 @@ Please consider removing this folder from the account and adding it again.</sour
         <translation>Flytta fjärrraderade filer till den lokala papperskorgen istället för att radera dem</translation>
     </message>
     <message>
+        <location filename="../src/gui/generalsettings.ui" line="125"/>
+        <source>Automatically merge text file conflicts when possible</source>
+        <translation>Sammanfoga konflikter i textfiler automatiskt när det är möjligt</translation>
+    </message>
+    <message>
         <location filename="../src/gui/generalsettings.ui" line="127"/>
         <source>Edit Ignored Files</source>
         <translation>Redigera ignorerade filer</translation>


### PR DESCRIPTION
## Context

Follow-up for https://github.com/orgs/opencloud-eu/discussions/2891.

This adds an opt-in client-side automerge path for text-file sync conflicts. The companion Craft dependency PR is https://github.com/opencloud-eu/craft-blueprints-opencloud/pull/6.

## Changes

- Add a persisted `autoMergeTextConflicts` setting and checkbox in General Settings.
- Add localized strings for the new setting across the existing desktop translation catalogs.
- Add libgit2 discovery/linking for `libsync`.
- Add a text conflict automerge helper that:
  - only runs for enabled text-file conflicts with a valid synced base journal record;
  - uses the server versions endpoint for the prior synced base version;
  - performs a three-way merge with libgit2 using Qt text-mode I/O for platform newline handling;
  - falls back to the existing conflicted-copy behavior when merge setup or merge execution fails.
- Wire the automerge attempt into the conflict download path before the normal conflict-copy fallback.

## Verification

- Enabled the setting in the active local config and confirmed `autoMergeTextConflicts=true`.
- Used a logged-in OpenCloud web UI session only as an auth source for WebDAV verification; no discussion post was made.
- Provoked a real sync conflict on `Codex Sync Tests/automerge-webui-20260605-1327.txt`:
  - base synced first;
  - local edit changed line 3;
  - remote WebDAV edit changed line 1;
  - client log showed `Automatically merged text conflict`;
  - no conflicted copy was created for that successful test;
  - local file and authenticated WebDAV GET both returned:

```text
remote line 1
base line 2
local line 3
```

- Rebuilt translations with `lrelease`; updated `.qm` generation completed successfully.
- Cleaned the local Craft `opencloud/opencloud-desktop` build tree and blueprint `__pycache__`, then rebuilt through Craft with the repo `.craft.ini` plus workflow override using `-i --install-deps --compile --install`.
- CMake configure found required `LibGit2` from the Craft prefix.
- Craft compile completed successfully (`450/450`), install succeeded, and qmerge succeeded.
- Verified the qmerged `OpenCloudLibSync.dll` depends on `git2.dll` with `dumpbin /dependents`.