### PR TITLE
refactor(gui-test): fix config parsing and use the report helper

### DIFF
--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -126,6 +126,7 @@ steps:
       BACKEND_HOST: https://opencloud:9200
       GUI_TEST_REPORT_DIR: /woodpecker/desktop/test/gui/reports
       BEHAVE_TEST_DIR: /woodpecker/desktop/test/gui
+      RECORD_VIDEO_ON_FAILURE: 'true'
       # Cannot handle this tags format inside a container: --tags='@smoke and not @skip'
       BEHAVE_PARAMETERS: '--tags=~@skip ${SUITES}'
 

--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -25,11 +25,7 @@ def before_feature(context, feature):
 
 
 def before_scenario(context, scenario):
-    if (
-        os.getenv("CI")
-        and get_config("record_video_on_failure")
-        and not hit_screenrecord_limit()
-    ):
+    if get_config("record_video_on_failure") and not hit_screenrecord_limit():
         ScreenRecorder.start_recording(normalize_scenario_title(scenario.name))
     elif hit_screenrecord_limit():
         print("[INFO] Screen recording limit reached.")
@@ -42,7 +38,7 @@ def after_step(context, step):
 
 def after_scenario(context, scenario):
     # stop screen recording
-    if os.getenv("CI") and get_config("record_video_on_failure"):
+    if get_config("record_video_on_failure"):
         ScreenRecorder.stop_recording(passed=scenario.status == Status.passed)
 
     # quit the application

--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -1,9 +1,6 @@
 import shutil
 import os
-import re
-import pyautogui
 from behave.model_core import Status
-from datetime import datetime
 
 from helpers import ScreenRecorder
 from helpers.ConfigHelper import init_config
@@ -13,32 +10,15 @@ from helpers.ConfigHelper import get_config
 from helpers.FilesHelper import prefix_path_namespace, cleanup_created_paths
 from helpers.AppHelper import close_and_kill_app
 from helpers.SyncHelper import clear_socket_messages
+from helpers.ReportHelper import (
+    normalize_scenario_title,
+    hit_screenrecord_limit,
+    take_screenshot,
+    append_scenario_to_app_log,
+    store_app_log,
+    cleanup_current_app_log,
+)
 from step_types.types import *  # register all step types
-
-
-def append_scenario_to_app_log(scenario):
-    with open(get_config('appLogFile'), 'a') as log_file:
-        logs = ["=" * 80]
-        logs.append(
-            f"Scenario: {scenario.name}\nLocation: {scenario.filename}:{scenario.line}"
-        )
-        logs.append("-" * 80)
-        logs.append("")  # extra line break
-        log_file.write("\n".join(logs))
-
-
-def store_app_log():
-    with open(get_config('appLogFile'), 'a') as log_file:
-        # client log is stored in utf-16.
-        with open(
-            get_config('currentAppLogFile'), 'r', encoding='utf-16'
-        ) as current_log:
-            log_file.write(f"{current_log.read()}\n\n")
-
-
-def cleanup_app_log():
-    if os.path.exists(get_config('currentAppLogFile')):
-        os.remove(get_config('currentAppLogFile'))
 
 
 def before_feature(context, feature):
@@ -46,27 +26,25 @@ def before_feature(context, feature):
 
 
 def before_scenario(context, scenario):
-    if os.getenv("CI"):
-        ScreenRecorder.start_recording(scenario)
+    if (
+        os.getenv("CI")
+        and get_config("record_video_on_failure")
+        and not hit_screenrecord_limit()
+    ):
+        ScreenRecorder.start_recording(normalize_scenario_title(scenario.name))
 
 
 def after_step(context, step):
     if step.status in [Status.failed, Status.error] and os.getenv("CI"):
-        scenario = context.scenario.name.lower()
-        scenario = re.sub(r'[^a-zA-Z0-9_]', '_', scenario)
-        timestamp = datetime.now().strftime("%d-%b-%Y_%H-%M-%S")
-        screenshots_dir = os.path.join(get_config("guiTestReportDir"), "screenshots")
-        os.makedirs(screenshots_dir, exist_ok=True)
-
-        file_path = os.path.join(screenshots_dir, f"{scenario}_{timestamp}.png")
-        pyautogui.screenshot(file_path)
+        take_screenshot(normalize_scenario_title(context.scenario.name))
 
 
 def after_scenario(context, scenario):
-
     # stop screen recording
-    if os.getenv("CI"):
+    if os.getenv("CI") and get_config("record_video_on_failure"):
         ScreenRecorder.stop_recording(passed=scenario.status == Status.passed)
+    if hit_screenrecord_limit():
+        print("[INFO] Screen recording limit reached.")
 
     # clean up sync dir
     if os.path.exists(get_config("clientRootSyncPath")):
@@ -93,5 +71,5 @@ def after_scenario(context, scenario):
     ):
         append_scenario_to_app_log(scenario)
         store_app_log()
-    cleanup_app_log()
+    cleanup_current_app_log()
     clear_socket_messages()

--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -14,8 +14,7 @@ from helpers.ReportHelper import (
     normalize_scenario_title,
     hit_screenrecord_limit,
     take_screenshot,
-    append_scenario_to_app_log,
-    store_app_log,
+    save_app_log,
     cleanup_current_app_log,
 )
 from step_types.types import *  # register all step types
@@ -32,6 +31,8 @@ def before_scenario(context, scenario):
         and not hit_screenrecord_limit()
     ):
         ScreenRecorder.start_recording(normalize_scenario_title(scenario.name))
+    elif hit_screenrecord_limit():
+        print("[INFO] Screen recording limit reached.")
 
 
 def after_step(context, step):
@@ -43,8 +44,15 @@ def after_scenario(context, scenario):
     # stop screen recording
     if os.getenv("CI") and get_config("record_video_on_failure"):
         ScreenRecorder.stop_recording(passed=scenario.status == Status.passed)
-    if hit_screenrecord_limit():
-        print("[INFO] Screen recording limit reached.")
+
+    # quit the application
+    close_and_kill_app()
+
+    # store app log on scenario failure
+    if scenario.status in [Status.failed, Status.error] and os.path.exists(
+        get_config('currentAppLogFile')
+    ):
+        save_app_log(scenario)
 
     # clean up sync dir
     if os.path.exists(get_config("clientRootSyncPath")):
@@ -62,14 +70,6 @@ def after_scenario(context, scenario):
     cleanup_created_paths()
     delete_project_spaces()
     delete_created_users()
-    # quit the application
-    close_and_kill_app()
 
-    # store app log on scenario failure
-    if scenario.status in [Status.failed, Status.error] and os.path.exists(
-        get_config('currentAppLogFile')
-    ):
-        append_scenario_to_app_log(scenario)
-        store_app_log()
     cleanup_current_app_log()
     clear_socket_messages()

--- a/test/gui/helpers/ConfigHelper.py
+++ b/test/gui/helpers/ConfigHelper.py
@@ -70,33 +70,40 @@ CONFIG_ENV_MAP = {
     'record_video_on_failure': 'RECORD_VIDEO_ON_FAILURE',
 }
 
+# immutable configs
 DEFAULT_PATH_CONFIG = {
     'custom_lib': os.path.abspath(
         os.path.join(os.path.dirname(__file__), 'custom_lib')
     ),
     'home_dir': get_default_home_dir(),
+    'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", APP_CONFIG_FILE),
     # allow to record first 5 videos
     'video_record_limit': 5,
-    'app_path': None,
-}
-
-# default config values
-CONFIG = {
-    'localBackendUrl': 'https://localhost:9200/',
-    'sync_timeout': 60,
     'max_timeout': 60,
     'min_timeout': 5,
     'lowest_timeout': 1,
-    'clientRootSyncPath': get_client_root_path(),
-    'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", APP_CONFIG_FILE),
-    'guiTestReportDir': os.path.join(CURRENT_DIR.parent, 'reports'),
-    'tempFolderPath': os.path.join(get_client_root_path(), 'temp'),
-    'record_video_on_failure': False,
     'files_for_upload': os.path.join(CURRENT_DIR.parent, 'files-for-upload'),
-    'syncConnectionName': 'Personal',
 }
 
-# Permission roles mapping
+# mutable configs
+CONFIG = {
+    'app_path': None,
+    'localBackendUrl': 'https://localhost:9200/',
+    'sync_timeout': 60,
+    'clientRootSyncPath': get_client_root_path(),
+    'tempFolderPath': os.path.join(get_client_root_path(), 'temp'),
+    'guiTestReportDir': os.path.join(CURRENT_DIR.parent, 'reports'),
+    'record_video_on_failure': False,
+    'syncConnectionName': 'Personal',
+    ###############################
+    # dynamic configs             #
+    ###############################
+    # currentAppLogFile: file path to store app logs for the current scenario run, initialized in init_config()
+    # appLogFile: file path to store cumulative app logs for the entire test run, initialized in init_config()
+    # currentUserSyncPath: path to store the current user's sync data, initialized in init_config()
+}
+
+# space membership permission roles mapping
 PERMISSION_ROLES = {
     'Viewer': 'b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5',
     'Editor': 'fb6c3e19-e378-47e5-b277-9732f9de6e21',
@@ -107,57 +114,56 @@ CONFIG.update(DEFAULT_PATH_CONFIG)
 READONLY_CONFIG = list(CONFIG_ENV_MAP.keys()) + list(DEFAULT_PATH_CONFIG.keys())
 
 
-def read_cfg_file(cfg_path):
+def read_config_from_file():
+    cfg_path = os.path.abspath(os.path.join(CURRENT_DIR.parent, 'config.ini'))
     cfg = ConfigParser()
-    if cfg.read(cfg_path):
-        for key, _ in CONFIG.items():
-            if key in CONFIG_ENV_MAP:
-                if value := cfg.get('DEFAULT', CONFIG_ENV_MAP[key]):
-                    if key == 'record_video_on_failure':
-                        CONFIG[key] = value == 'true'
-                    else:
-                        CONFIG[key] = value
+
+    if not cfg.read(cfg_path):
+        return
+    for key in CONFIG:
+        if key in CONFIG_ENV_MAP and cfg.get('DEFAULT', CONFIG_ENV_MAP[key]):
+            value = cfg.get('DEFAULT', CONFIG_ENV_MAP[key])
+            CONFIG[key] = value
 
 
-def init_config():
-    # try reading configs from config.ini
-    try:
-        cfg_path = os.path.abspath(os.path.join(CURRENT_DIR.parent, 'config.ini'))
-        read_cfg_file(cfg_path)
-    except:
-        pass
-
-    # read and override configs from environment variables
+def read_config_from_env():
     for key, value in CONFIG_ENV_MAP.items():
         if os.environ.get(value):
-            if key == 'record_video_on_failure':
-                CONFIG[key] = os.environ.get(value) == 'true'
-            else:
-                CONFIG[key] = os.environ.get(value)
+            CONFIG[key] = os.environ.get(value)
 
-    # Set the default values if empty
+
+def normalize_configs():
     for key, value in CONFIG.items():
-        if key in ('sync_timeout', 'max_timeout', 'min_timeout', 'lowest_timeout'):
+        if key in ('sync_timeout'):
             CONFIG[key] = builtins.int(value)
-        elif key == 'localBackendUrl':
-            # make sure there is always one trailing slash
-            CONFIG[key] = value.rstrip('/') + '/'
+        elif key == 'record_video_on_failure':
+            CONFIG[key] = value == 'true'
         elif key in (
+            'localBackendUrl',
             'clientRootSyncPath',
             'tempFolderPath',
             'guiTestReportDir',
         ):
             # make sure there is always one trailing slash
-            if is_windows():
-                value = value.replace('/', '\\')
-                CONFIG[key] = value.rstrip('\\') + '\\'
-            else:
-                CONFIG[key] = value.rstrip('/') + '/'
+            CONFIG[key] = value.rstrip('/') + '/'
+
+
+def init_config():
+    # read and override configs from config.ini
+    read_config_from_file()
+
+    # read and override configs from environment variables
+    read_config_from_env()
+
+    # typecast and normalize config values
+    normalize_configs()
 
     if 'app_path' not in CONFIG or not CONFIG['app_path']:
         raise KeyError('APP_PATH must be set in config.ini or environment variables')
     if not os.path.exists(CONFIG['app_path']):
         raise KeyError(f'App not found: {CONFIG["app_path"]}')
+    if not os.path.isfile(CONFIG['app_path']):
+        raise KeyError(f'App path is not a file: {CONFIG["app_path"]}')
 
     ### initialize dynamic config values
     # file to store app logs for the current scenario run

--- a/test/gui/helpers/ReportHelper.py
+++ b/test/gui/helpers/ReportHelper.py
@@ -1,10 +1,14 @@
 import os
-import glob
-import shutil
-import test
+import re
+import pyautogui
 
 from helpers.ConfigHelper import get_config
-from helpers.FilesHelper import prefix_path_namespace
+
+
+def normalize_scenario_title(title):
+    scenario_title = title.lower().strip()
+    scenario_title = re.sub(r'\W', '_', scenario_title)
+    return scenario_title
 
 
 def get_screenrecords_path():
@@ -15,11 +19,15 @@ def get_screenshots_path():
     return os.path.join(get_config("guiTestReportDir"), "screenshots")
 
 
-def is_video_enabled():
-    return get_config("record_video_on_failure") and not reached_video_limit()
+def get_screenrecord_file_path(filename):
+    report_dir = get_screenrecords_path()
+    if not os.path.exists(report_dir):
+        os.makedirs(report_dir)
+
+    return os.path.join(report_dir, f"{filename}.mp4")
 
 
-def reached_video_limit():
+def hit_screenrecord_limit():
     video_report_dir = get_screenrecords_path()
     if not os.path.exists(video_report_dir):
         return False
@@ -27,43 +35,37 @@ def reached_video_limit():
     return len(entries) >= get_config("video_record_limit")
 
 
-def save_video_recording(filename, test_failed):
-    try:
-        # do not throw if stopVideoCapture() fails
-        test.stopVideoCapture()
-    except:
-        test.log("Failed to stop screen recording")
-
-    if not (video_dir := squishinfo.resultDir):
-        video_dir = squishinfo.testCase
-    else:
-        test_case = "/".join(squishinfo.testCase.split("/")[-2:])
-        video_dir = os.path.join(video_dir, test_case)
-    video_dir = os.path.join(video_dir, "attachments")
-
-    # if the test failed
-    # move videos to the screenrecords directory
-    if test_failed:
-        video_files = glob.glob(f"{video_dir}/**/*.mp4", recursive=True)
-        screenrecords_dir = get_screenrecords_path()
-        if not os.path.exists(screenrecords_dir):
-            os.makedirs(screenrecords_dir)
-        # reverse the list to get the latest video first
-        video_files.reverse()
-        for idx, video in enumerate(video_files):
-            if idx:
-                file_parts = filename.rsplit(".", 1)
-                filename = f"{file_parts[0]}_{idx+1}.{file_parts[1]}"
-            shutil.move(video, os.path.join(screenrecords_dir, filename))
-    # remove the video directory
-    shutil.rmtree(prefix_path_namespace(video_dir))
-
-
 def take_screenshot(filename):
     directory = get_screenshots_path()
     if not os.path.exists(directory):
         os.makedirs(directory)
+    file_path = os.path.join(directory, f"{filename}.png")
     try:
-        squish.saveDesktopScreenshot(os.path.join(directory, filename))
-    except:
-        test.log("Failed to save screenshot")
+        pyautogui.screenshot(file_path)
+    except Exception as e:
+        print(f"[WARN] Failed to save screenshot: {e}")
+
+
+def append_scenario_to_app_log(scenario):
+    with open(get_config('appLogFile'), 'a') as log_file:
+        logs = ["=" * 80]
+        logs.append(
+            f"Scenario: {scenario.name}\nLocation: {scenario.filename}:{scenario.line}"
+        )
+        logs.append("-" * 80)
+        logs.append("")  # extra line break
+        log_file.write("\n".join(logs))
+
+
+def store_app_log():
+    with open(get_config('appLogFile'), 'a') as log_file:
+        # client log is stored in utf-16.
+        with open(
+            get_config('currentAppLogFile'), 'r', encoding='utf-16'
+        ) as current_log:
+            log_file.write(f"{current_log.read()}\n\n")
+
+
+def cleanup_current_app_log():
+    if os.path.exists(get_config('currentAppLogFile')):
+        os.remove(get_config('currentAppLogFile'))

--- a/test/gui/helpers/ReportHelper.py
+++ b/test/gui/helpers/ReportHelper.py
@@ -46,7 +46,7 @@ def take_screenshot(filename):
         print(f"[WARN] Failed to save screenshot: {e}")
 
 
-def append_scenario_to_app_log(scenario):
+def save_app_log(scenario):
     with open(get_config('appLogFile'), 'a') as log_file:
         logs = ["=" * 80]
         logs.append(
@@ -55,10 +55,6 @@ def append_scenario_to_app_log(scenario):
         logs.append("-" * 80)
         logs.append("")  # extra line break
         log_file.write("\n".join(logs))
-
-
-def store_app_log():
-    with open(get_config('appLogFile'), 'a') as log_file:
         # client log is stored in utf-16.
         with open(
             get_config('currentAppLogFile'), 'r', encoding='utf-16'

--- a/test/gui/helpers/ReportHelper.py
+++ b/test/gui/helpers/ReportHelper.py
@@ -12,7 +12,7 @@ def normalize_scenario_title(title):
 
 
 def get_screenrecords_path():
-    return os.path.join(get_config("guiTestReportDir"), "screenrecords")
+    return os.path.join(get_config("guiTestReportDir"), "recordings")
 
 
 def get_screenshots_path():

--- a/test/gui/helpers/ScreenRecorder.py
+++ b/test/gui/helpers/ScreenRecorder.py
@@ -1,28 +1,15 @@
 import os
-import re
 import threading
 import time
 import mss
 import numpy as np
 import imageio_ffmpeg
-from datetime import datetime
 
-from helpers.ConfigHelper import get_config
-
+from helpers.ReportHelper import get_screenrecord_file_path
 
 _recording_thread = None
 _stop_event = threading.Event()
 _video_path = None
-
-
-def _build_video_path(scenario):
-    safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", scenario.name)
-    timestamp = datetime.now().strftime("%d-%b-%Y_%H-%M-%S")
-
-    recordings_dir = os.path.join(get_config("guiTestReportDir"), "recordings")
-    os.makedirs(recordings_dir, exist_ok=True)
-
-    return os.path.join(recordings_dir, f"{safe_name}_{timestamp}.mp4")
 
 
 def _record_loop(video_path):
@@ -39,7 +26,8 @@ def _record_loop(video_path):
         )
         writer.send(None)
 
-        interval = 1.0 / 24 # 1/24 seconds between each frame so we get 24 frames per second
+        # 1/24 seconds between each frame so we get 24 frames per second
+        interval = 1.0 / 24
         next_frame_at = time.monotonic()
 
         while not _stop_event.is_set():
@@ -56,13 +44,15 @@ def _record_loop(video_path):
         writer.close()
 
 
-def start_recording(scenario):
+def start_recording(filename):
     global _recording_thread, _video_path
 
-    _video_path = _build_video_path(scenario)
+    _video_path = get_screenrecord_file_path(filename)
     _stop_event.clear()
 
-    _recording_thread = threading.Thread(target=_record_loop, args=(_video_path,), daemon=True)
+    _recording_thread = threading.Thread(
+        target=_record_loop, args=(_video_path,), daemon=True
+    )
     _recording_thread.start()
 
 

--- a/test/gui/woodpecker/server.ini
+++ b/test/gui/woodpecker/server.ini
@@ -1,3 +1,0 @@
-[General]
-AUT/opencloud = "/woodpecker/desktop/build/bin"
-AUTPMTimeout = "15000"


### PR DESCRIPTION
- Fix config parsing and normalization
- Use ReportHelper for report paths
- Screen recording is disabled by default
  - use `RECORD_VIDEO_ON_FAILURE=true` to enable the screen recording
  - enabled in CI
  - NOTE: the limit of screen recordings is 5. This is to prevent large test reports size