### PR TITLE
chore(gui-test): add ruff formatter

### DIFF
--- a/.woodpecker/python-lint.yaml
+++ b/.woodpecker/python-lint.yaml
@@ -1,0 +1,22 @@
+variables:
+  - &astral_uv_image 'astral/uv:python3.12-trixie'
+when:
+  - branch:
+      - main
+      - stable-*
+    event:
+      - push
+      - manual
+  - event: pull_request
+
+workspace:
+  base: /woodpecker
+  path: desktop
+
+steps:
+  - name: lint-test-code
+    image: *astral_uv_image
+    commands:
+      - cd test/gui
+      - uv sync --only-group lint 
+      - make python-lint

--- a/test/gui/Makefile
+++ b/test/gui/Makefile
@@ -34,7 +34,7 @@ check-uv:
 .PHONY: uv-install
 uv-install: check-uv
 	uv venv --system-site-packages --allow-existing
-	uv sync --frozen
+	uv sync --frozen --all-groups
 
 .PHONY: install-chromium
 install-chromium: check-uv
@@ -45,14 +45,12 @@ run-atpsi-webdriver: check-uv
 	bash woodpecker/run_atspi_webdriver.sh
 
 .PHONY: python-lint
-python-lint:
-	black --check --diff .
-	python3 -m pylint --rcfile ./.pylintrc $(PYTHON_LINT_PATHS)
+python-lint: check-uv
+	uv run --no-sync ruff format . --check
 
 .PHONY: python-lint-fix
-python-lint-fix:
-	black .
-	python3 -m pylint --rcfile ./.pylintrc $(PYTHON_LINT_PATHS)
+python-lint-fix: check-uv
+	uv run --no-sync ruff format .
 
 .PHONY: gherkin-lint
 gherkin-lint:

--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -95,7 +95,7 @@ def create_app_session():
         f'{get_config("app_path")} -s {command_args} --logdebug',
     )
     options.set_capability('appium:environ', get_app_env())
-    options.set_capability('timeouts', { 'implicit': get_config('min_timeout') * 1000 })
+    options.set_capability('timeouts', {'implicit': get_config('min_timeout') * 1000})
     app_driver = Remote(command_executor=get_config('webdriver_url'), options=options)
     # NOTE: these methods to set implicit wait are not working:
     # app_driver.implicitly_wait(5)

--- a/test/gui/helpers/SetupClientHelper.py
+++ b/test/gui/helpers/SetupClientHelper.py
@@ -1,4 +1,4 @@
-﻿from urllib.parse import urlparse
+from urllib.parse import urlparse
 from os import makedirs
 from os.path import exists, join
 from PySide6.QtCore import QSettings, QUuid, QUrl, QJsonValue

--- a/test/gui/helpers/SpaceHelper.py
+++ b/test/gui/helpers/SpaceHelper.py
@@ -48,10 +48,12 @@ def get_project_spaces(user=None):
     search_query = '$filter=driveType eq \'project\''
     return fetch_spaces(query=search_query, user=user)
 
+
 def get_personal_space_id(user):
     search_query = '$filter=driveType eq \'personal\''
     space = fetch_spaces(query=search_query, user=user)
     return space[0]['id']
+
 
 def get_space_id(space_name, user=None):
     spaces = {**created_spaces, **user_spaces}

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -290,8 +290,10 @@ def wait_for_resource_to_sync(
     if synced:
         if check_queued:
             loaded = wait_for(
-                lambda: not SyncConnection.is_sync_in_progress(
-                    get_config('syncConnectionName')
+                lambda: (
+                    not SyncConnection.is_sync_in_progress(
+                        get_config('syncConnectionName')
+                    )
                 ),
                 get_config('sync_timeout'),
             )

--- a/test/gui/helpers/VFSFileHelper.py
+++ b/test/gui/helpers/VFSFileHelper.py
@@ -8,6 +8,7 @@ from helpers.ConfigHelper import is_windows
 
 error_message = "'%s' function is only supported in Windows OS."
 
+
 # ==========================
 # Structures
 # ==========================
@@ -16,6 +17,7 @@ class FILETIME(ctypes.Structure):
         ("dwLowDateTime", wintypes.DWORD),
         ("dwHighDateTime", wintypes.DWORD),
     ]
+
 
 class WIN32_FILE_ATTRIBUTE_DATA(ctypes.Structure):
     _fields_ = [
@@ -27,6 +29,7 @@ class WIN32_FILE_ATTRIBUTE_DATA(ctypes.Structure):
         ("nFileSizeLow", wintypes.DWORD),
     ]
 
+
 # Ref: https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
 @unique
 class FileAttributeConstants(IntFlag):
@@ -34,6 +37,7 @@ class FileAttributeConstants(IntFlag):
     FILE_ATTRIBUTE_PINNED = 0x00080000
     FILE_ATTRIBUTE_UNPINNED = 0x00100000
     FILE_ATTRIBUTE_ARCHIVE = 0x00000020
+
 
 GetFileAttributesExW = None
 GetCompressedFileSizeW = None
@@ -65,9 +69,9 @@ def get_file_attributes(path):
             raise ctypes.WinError(ctypes.get_last_error())
         attributes = FileAttributeConstants(data.dwFileAttributes)
         mask = (
-            FileAttributeConstants.FILE_ATTRIBUTE_PINNED |
-            FileAttributeConstants.FILE_ATTRIBUTE_UNPINNED |
-            FileAttributeConstants.FILE_ATTRIBUTE_ARCHIVE
+            FileAttributeConstants.FILE_ATTRIBUTE_PINNED
+            | FileAttributeConstants.FILE_ATTRIBUTE_UNPINNED
+            | FileAttributeConstants.FILE_ATTRIBUTE_ARCHIVE
         )
         return attributes & mask
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
@@ -89,19 +93,28 @@ def get_compressed_file_size(path):
 
 def resource_archived(resource_path):
     if is_windows():
-        return bool(get_file_attributes(resource_path) & FileAttributeConstants.FILE_ATTRIBUTE_ARCHIVE)
+        return bool(
+            get_file_attributes(resource_path)
+            & FileAttributeConstants.FILE_ATTRIBUTE_ARCHIVE
+        )
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
 
 
 def resource_pinned(resource_path):
     if is_windows():
-        return bool(get_file_attributes(resource_path) & FileAttributeConstants.FILE_ATTRIBUTE_PINNED)
+        return bool(
+            get_file_attributes(resource_path)
+            & FileAttributeConstants.FILE_ATTRIBUTE_PINNED
+        )
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
 
 
 def resource_unpinned(resource_path):
     if is_windows():
-        return bool(get_file_attributes(resource_path) & FileAttributeConstants.FILE_ATTRIBUTE_UNPINNED)
+        return bool(
+            get_file_attributes(resource_path)
+            & FileAttributeConstants.FILE_ATTRIBUTE_UNPINNED
+        )
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
 
 

--- a/test/gui/helpers/api/http_helper.py
+++ b/test/gui/helpers/api/http_helper.py
@@ -55,6 +55,6 @@ def assert_http_status(response, expected_code, message=""):
     if response.text:
         response_body = response.text
 
-    assert (
-        response.status_code == expected_code
-    ), f"{message}\nRequest failed with status code '{response.status_code}'\n{response_body}"
+    assert response.status_code == expected_code, (
+        f"{message}\nRequest failed with status code '{response.status_code}'\n{response_body}"
+    )

--- a/test/gui/helpers/api/webdav_helper.py
+++ b/test/gui/helpers/api/webdav_helper.py
@@ -48,7 +48,9 @@ def get_folder_items(user, resource):
     xml_response = request.propfind(path, user=user)
 
     if xml_response.status_code != 207:
-        raise AssertionError(f'Failed to get resource properties: {xml_response.status_code}')
+        raise AssertionError(
+            f'Failed to get resource properties: {xml_response.status_code}'
+        )
 
     return ET.fromstring(xml_response.content)
 
@@ -70,9 +72,9 @@ def get_folder_items_count(user, folder_name):
 def create_folder(user, folder_name):
     url = get_resource_path(user, folder_name)
     response = request.mkcol(url, user=user)
-    assert (
-        response.status_code == 201
-    ), f'Could not create the folder: {folder_name} for user {user}'
+    assert response.status_code == 201, (
+        f'Could not create the folder: {folder_name} for user {user}'
+    )
 
 
 def create_file(user, file_name, contents):
@@ -122,7 +124,9 @@ def get_user_id(username):
     if username in provisioning.created_users:
         return provisioning.created_users[username]['id']
 
-    raise AssertionError(f'User {username} not found in created users. Make sure the user is created first.')
+    raise AssertionError(
+        f'User {username} not found in created users. Make sure the user is created first.'
+    )
 
 
 def send_resource_share_invitation(user, resource, sharee, permission_role):
@@ -131,17 +135,18 @@ def send_resource_share_invitation(user, resource, sharee, permission_role):
     recipient_user_id = get_user_id(sharee)
     role_id = get_permission_role_id(permission_role)
 
-    url = url_join(get_beta_graph_url(), "drives", space_id, "items", resource_id, "invite")
+    url = url_join(
+        get_beta_graph_url(), "drives", space_id, "items", resource_id, "invite"
+    )
 
     body = {
         "roles": [role_id],
         "recipients": [
-            {
-                "objectId": recipient_user_id,
-                "@libre.graph.recipient.type": "user"
-            }
-        ]
+            {"objectId": recipient_user_id, "@libre.graph.recipient.type": "user"}
+        ],
     }
 
     response = request.post(url, body=json.dumps(body), user=user)
-    assert response.status_code in [200, 201], f"Failed to send share invitation: {response.status_code}"
+    assert response.status_code in [200, 201], (
+        f"Failed to send share invitation: {response.status_code}"
+    )

--- a/test/gui/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/pageObjects/AccountConnectionWizard.py
@@ -28,11 +28,11 @@ class AccountConnectionWizard:
     )
     SELECT_LOCAL_FOLDER_BUTTON = SimpleNamespace(
         by=By.ACCESSIBILITY_ID,
-        selector="QApplication.Settings.centralwidget.dialogStack.SetupWizardWidget.contentWidget.AccountConfiguredWizardPage.advancedConfigGroupBox.advancedConfigGroupBoxContentWidget.localDirectoryGroupBox.chooseLocalDirectoryButton"
+        selector="QApplication.Settings.centralwidget.dialogStack.SetupWizardWidget.contentWidget.AccountConfiguredWizardPage.advancedConfigGroupBox.advancedConfigGroupBoxContentWidget.localDirectoryGroupBox.chooseLocalDirectoryButton",
     )
     LOCAL_DOWNLOAD_DIRECTORY_INPUT = SimpleNamespace(
         by=By.ACCESSIBILITY_ID,
-        selector="QApplication.Settings.centralwidget.dialogStack.SetupWizardWidget.contentWidget.AccountConfiguredWizardPage.advancedConfigGroupBox.advancedConfigGroupBoxContentWidget.localDirectoryGroupBox.localDirectoryLineEdit"
+        selector="QApplication.Settings.centralwidget.dialogStack.SetupWizardWidget.contentWidget.AccountConfiguredWizardPage.advancedConfigGroupBox.advancedConfigGroupBoxContentWidget.localDirectoryGroupBox.localDirectoryLineEdit",
     )
     DIRECTORY_NAME_BOX = SimpleNamespace(
         by=By.ACCESSIBILITY_ID,
@@ -55,7 +55,9 @@ class AccountConnectionWizard:
         by=By.ACCESSIBILITY_ID,
         selector="QApplication.QFileDialog.fileNameEdit",
     )
-    SYNC_EVERYTHING_RADIO_BUTTON = SimpleNamespace(by=By.NAME, selector="Synchronize all existing spaces")
+    SYNC_EVERYTHING_RADIO_BUTTON = SimpleNamespace(
+        by=By.NAME, selector="Synchronize all existing spaces"
+    )
 
     @staticmethod
     def add_server(server_url):
@@ -189,15 +191,19 @@ class AccountConnectionWizard:
     def select_download_everything_option():
         app().find_element(
             AccountConnectionWizard.SYNC_EVERYTHING_RADIO_BUTTON.by,
-            AccountConnectionWizard.SYNC_EVERYTHING_RADIO_BUTTON.selector
+            AccountConnectionWizard.SYNC_EVERYTHING_RADIO_BUTTON.selector,
         ).click()
 
     @staticmethod
     def is_credential_window_visible():
-        visible = app().find_element(
-            AccountConnectionWizard.LOGIN_DIALOG.by,
-            AccountConnectionWizard.LOGIN_DIALOG.selector
-        ).is_displayed()
+        visible = (
+            app()
+            .find_element(
+                AccountConnectionWizard.LOGIN_DIALOG.by,
+                AccountConnectionWizard.LOGIN_DIALOG.selector,
+            )
+            .is_displayed()
+        )
         return visible
 
     @staticmethod
@@ -212,8 +218,8 @@ class AccountConnectionWizard:
         can_change = False
         try:
             app().find_element(
-            AccountConnectionWizard.SELECT_LOCAL_FOLDER_BUTTON.by,
-            AccountConnectionWizard.SELECT_LOCAL_FOLDER_BUTTON.selector
+                AccountConnectionWizard.SELECT_LOCAL_FOLDER_BUTTON.by,
+                AccountConnectionWizard.SELECT_LOCAL_FOLDER_BUTTON.selector,
             ).click()
             app().find_element(
                 AccountConnectionWizard.DIRECTORY_NAME_BOX.by,
@@ -221,7 +227,7 @@ class AccountConnectionWizard:
             )
             app().find_element(
                 AccountConnectionWizard.CHOOSE_FOLDER_BUTTON.by,
-                AccountConnectionWizard.CHOOSE_FOLDER_BUTTON.selector
+                AccountConnectionWizard.CHOOSE_FOLDER_BUTTON.selector,
             )
             can_change = True
         except:
@@ -232,7 +238,7 @@ class AccountConnectionWizard:
     def is_sync_everything_option_checked():
         element = app().find_element(
             AccountConnectionWizard.SYNC_EVERYTHING_RADIO_BUTTON.by,
-            AccountConnectionWizard.SYNC_EVERYTHING_RADIO_BUTTON.selector
+            AccountConnectionWizard.SYNC_EVERYTHING_RADIO_BUTTON.selector,
         )
         return element.get_attribute("checked") == "true"
 
@@ -240,6 +246,6 @@ class AccountConnectionWizard:
     def get_local_sync_path():
         element = app().find_element(
             AccountConnectionWizard.LOCAL_DOWNLOAD_DIRECTORY_INPUT.by,
-            AccountConnectionWizard.LOCAL_DOWNLOAD_DIRECTORY_INPUT.selector
+            AccountConnectionWizard.LOCAL_DOWNLOAD_DIRECTORY_INPUT.selector,
         )
         return str(element.text)

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -23,7 +23,9 @@ class Activity:
         by=By.ACCESSIBILITY_ID,
         selector="QApplication.Settings.centralwidget.dialogStack.page.stack.OCC::ActivitySettings.QTabWidget.qt_tabwidget_stackedwidget.OCC__IssuesWidget._filterButton",
     )
-    NOT_SYNCED_ACTIVITY_CONFLICT_FILE = SimpleNamespace(by=By.XPATH, selector="//*[starts-with(@name, '{filename} (conflicted copy')]")
+    NOT_SYNCED_ACTIVITY_CONFLICT_FILE = SimpleNamespace(
+        by=By.XPATH, selector="//*[starts-with(@name, '{filename} (conflicted copy')]"
+    )
     SYNCED_ACTIVITY_STATUS = SimpleNamespace(by=By.NAME, selector=None)
 
     @staticmethod
@@ -35,11 +37,17 @@ class Activity:
     def has_conflict_file(filename):
         filename = filename.rsplit(".", 1)[0]
         has_activity = wait_for(
-            lambda: app().find_element(
-                Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.by,
-                Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.selector.format(filename=filename)
-            ).is_displayed(),
-            get_config('max_timeout')
+            lambda: (
+                app()
+                .find_element(
+                    Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.by,
+                    Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.selector.format(
+                        filename=filename
+                    ),
+                )
+                .is_displayed()
+            ),
+            get_config('max_timeout'),
         )
         if not has_activity:
             raise AssertionError(f"File conflict activity not found")

--- a/test/gui/pageObjects/PublicLinkDialog.py
+++ b/test/gui/pageObjects/PublicLinkDialog.py
@@ -284,7 +284,7 @@ class PublicLinkDialog:
             squish.waitForObject(PublicLinkDialog.CONFIRM_LINK_DELETE_BUTTON)
         )
         squish.waitFor(
-            lambda: (not object.exists(PublicLinkDialog.DELETE_LINK_BUTTON)),
+            lambda: not object.exists(PublicLinkDialog.DELETE_LINK_BUTTON),
         )
 
     @staticmethod

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -97,7 +97,7 @@ class SyncConnection:
                 SyncConnection.FOLDER_SYNC_CONNECTION_MENU_BUTTON.selector.format(
                     sync_folder=sync_folder,
                     sync_path=get_config('currentUserSyncPath'),
-                    status="success"
+                    status="success",
                 ),
                 timeout=get_config("lowest_timeout"),
             )

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -13,13 +13,10 @@ class SyncConnectionWizard:
     )
     BACK_BUTTON = SimpleNamespace(by=By.NAME, selector="< Back")
     NEXT_BUTTON = SimpleNamespace(by=By.NAME, selector="Next >")
-    SELECTIVE_SYNC_ROOT_FOLDER = SimpleNamespace(
-        by=By.NAME,
-        selector=None
-    )
+    SELECTIVE_SYNC_ROOT_FOLDER = SimpleNamespace(by=By.NAME, selector=None)
     SELECTIVE_SYNC_TREE_FOLDER = SimpleNamespace(
         by=By.XPATH,
-        selector="//table_cell[@name and contains(@states, 'checkable') and @name!='{space}']"
+        selector="//table_cell[@name and contains(@states, 'checkable') and @name!='{space}']",
     )
     ADD_SYNC_CONNECTION_BUTTON = SimpleNamespace(
         by=By.XPATH, selector="//dialog[@name='Add Space']//*[@name='Add Space']"
@@ -62,7 +59,7 @@ class SyncConnectionWizard:
     def back():
         app().find_element(
             SyncConnectionWizard.BACK_BUTTON.by,
-            SyncConnectionWizard.BACK_BUTTON.selector
+            SyncConnectionWizard.BACK_BUTTON.selector,
         ).click()
 
     @staticmethod
@@ -78,7 +75,9 @@ class SyncConnectionWizard:
     def sort_by(header_text):
         element = app().find_element(
             SyncConnectionWizard.SELECTIVE_SYNC_TREE_HEADER.by,
-            SyncConnectionWizard.SELECTIVE_SYNC_TREE_HEADER.selector.format(header=header_text)
+            SyncConnectionWizard.SELECTIVE_SYNC_TREE_HEADER.selector.format(
+                header=header_text
+            ),
         )
         # ISSUE: https://github.com/opencloud-eu/desktop/pull/879
         # Cannot select table header element by click event
@@ -98,19 +97,20 @@ class SyncConnectionWizard:
     def get_item_name_from_row(row_index):
         elements = app().find_elements(
             SyncConnectionWizard.SELECTIVE_SYNC_TREE_FOLDER.by,
-            SyncConnectionWizard.SELECTIVE_SYNC_TREE_FOLDER.selector.format(space=get_config("syncConnectionName"))
+            SyncConnectionWizard.SELECTIVE_SYNC_TREE_FOLDER.selector.format(
+                space=get_config("syncConnectionName")
+            ),
         )
         return str(elements[row_index].text)
-
 
     @staticmethod
     def is_root_folder_checked():
         element = app().find_element(
             SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER.by,
-            get_config("syncConnectionName")
+            get_config("syncConnectionName"),
         )
         return element.get_attribute("checked") == "true"
-        
+
     @staticmethod
     def cancel_folder_sync_connection_wizard():
         app().find_element(
@@ -150,7 +150,7 @@ class SyncConnectionWizard:
     def get_local_sync_path():
         element = app().find_element(
             SyncConnectionWizard.CHOOSE_LOCAL_SYNC_FOLDER.by,
-            SyncConnectionWizard.CHOOSE_LOCAL_SYNC_FOLDER.selector
+            SyncConnectionWizard.CHOOSE_LOCAL_SYNC_FOLDER.selector,
         )
         return str(element.text)
 
@@ -158,7 +158,7 @@ class SyncConnectionWizard:
     def is_add_space_button_enabled():
         element = app().find_element(
             SyncConnectionWizard.ADD_SPACE_BUTTON.by,
-            SyncConnectionWizard.ADD_SPACE_BUTTON.selector
+            SyncConnectionWizard.ADD_SPACE_BUTTON.selector,
         )
         return element.is_enabled()
 

--- a/test/gui/pyproject.toml
+++ b/test/gui/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "appium-python-client==5.3.*",
     "behave==1.3.*",
     "behave-html-pretty-formatter==1.16.*",
-    "black==24.3.*",
     "flask==3.0.* ; sys_platform == 'linux'",
     "imageio-ffmpeg==0.6.*",
     "mss==9.*",
@@ -27,3 +26,11 @@ dependencies = [
     "requests==2.32.*",
     "sure==2.0.*",
 ]
+
+[dependency-groups]
+lint = [
+    "ruff>=0.15.20",
+]
+
+[tool.ruff.format]
+quote-style = "preserve"

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -238,8 +238,8 @@ def step(context, sync_path, wizard):
         actual_sync_path = AccountConnectionWizard.get_local_sync_path()
     else:
         actual_sync_path = SyncConnectionWizard.get_local_sync_path()
-        
-    with ensure('The actual sync path does not match the expected sync path' ):
+
+    with ensure('The actual sync path does not match the expected sync path'):
         actual_sync_path.should.equal(convert_path_separators_for_os(sync_path))
 
 

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -323,7 +323,9 @@ def step(context, username, file):
         f.read()
 
 
-@When(r'user "{username}" moves {resource_type} "{resource_name}" from the temp folder into the sync folder')
+@When(
+    r'user "{username}" moves {resource_type} "{resource_name}" from the temp folder into the sync folder'
+)
 def step(context, username, resource_type, resource_name):
     source_dir = join(get_config('test_temp_dir'), resource_name)
     move_resource(username, resource_type, source_dir, '/', True)
@@ -371,7 +373,9 @@ def step(context, user, file_name, content):
         content.should.equal(file_content)
 
 
-@Then('user "{user}" should not be able to edit the file "{file_name}" on the file system')
+@Then(
+    'user "{user}" should not be able to edit the file "{file_name}" on the file system'
+)
 def step(context, user, file_name):
     file_path = get_resource_path(file_name, user)
     with ensure('File should not be writable, but it is'):

--- a/test/gui/steps/server_context.py
+++ b/test/gui/steps/server_context.py
@@ -54,7 +54,9 @@ def step(context, user_name, file_name, content):
         text_content.should.equal(content)
 
 
-@Then(r'as user "{user_name}" folder "{folder_name}" should contain "{items_number}" items in the server')
+@Then(
+    r'as user "{user_name}" folder "{folder_name}" should contain "{items_number}" items in the server'
+)
 def step(context, user_name, folder_name, items_number):
     total_items = webdav.get_folder_items_count(user_name, folder_name)
     with ensure(f'Folder should contain {items_number} items'):
@@ -78,7 +80,9 @@ def step(context):
     Toolbar.open_settings_tab()
 
 
-@When('user "{user}" uploads file with content "{file_content}" to "{file_name}" in the server')
+@When(
+    'user "{user}" uploads file with content "{file_content}" to "{file_name}" in the server'
+)
 def step(context, user, file_content, file_name):
     webdav.create_file(user, file_name, file_content)
 
@@ -107,21 +111,22 @@ def step(context, user_name, server_file_name, local_file_name):
     local_content = get_document_content(get_file_for_upload(local_file_name))
 
     with ensure(
-            f"Server file '{server_file_name}' differs from local file '{local_file_name}'",
+        f"Server file '{server_file_name}' differs from local file '{local_file_name}'",
     ):
         server_content.should.equal(local_content)
 
 
-@Then('as "{user_name}" following files should not exist in the server',)
+@Then(
+    'as "{user_name}" following files should not exist in the server',
+)
 def step(context, user_name):
     for row in context.table:
         resource_name = row[0]
         resource_exists = webdav.resource_exists(user_name, resource_name)
         with ensure(
-             f"Resource '{resource_name}' should not exist, but it does",
+            f"Resource '{resource_name}' should not exist, but it does",
         ):
             resource_exists.should.be.false
-
 
 
 @Given('user "{user}" has uploaded the following files to the server')

--- a/test/gui/steps/vfs_context.py
+++ b/test/gui/steps/vfs_context.py
@@ -15,7 +15,10 @@ def step(context, file_name):
     test.compare(is_file_downloaded(resource_path), True, f"File is downloaded")
 
 
-@When(r'user "([^"]*)" marks (?:file|folder) "([^"]*)" as "(Free up space|Always keep on this device)" from the file explorer', regexp=True)
+@When(
+    r'user "([^"]*)" marks (?:file|folder) "([^"]*)" as "(Free up space|Always keep on this device)" from the file explorer',
+    regexp=True,
+)
 def step(context, user, resource, action):
     resource_path = get_resource_path(resource, user)
     perform_file_explorer_vfs_action(resource_path, action)

--- a/test/gui/uv.lock
+++ b/test/gui/uv.lock
@@ -74,36 +74,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "24.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/5f/bac24a952668c7482cfdb4ebf91ba57a796c9da8829363a772040c1a3312/black-24.3.0.tar.gz", hash = "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f", size = 634292, upload-time = "2024-03-15T19:35:43.699Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/32/1a25d1b83147ca128797a627f429f9dc390eb066805c6aa319bea3ffffa5/black-24.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395", size = 1587891, upload-time = "2024-03-15T19:43:32.908Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/91/6cb204786acc693edc4bf1b9230ffdc3cbfaeb7cd04d3a12fb4b13882a53/black-24.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995", size = 1434886, upload-time = "2024-03-15T19:41:59.067Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/e4/53b5d07117381f7d5e946a54dd4c62617faad90713649619bbc683769dfe/black-24.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7", size = 1747400, upload-time = "2024-03-15T19:38:22.142Z" },
-    { url = "https://files.pythonhosted.org/packages/13/9c/f2e7532d11b05add5ab383a9f90be1a49954bf510803f98064b45b42f98e/black-24.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0", size = 1363816, upload-time = "2024-03-15T19:39:43.559Z" },
-    { url = "https://files.pythonhosted.org/packages/68/df/ceea5828be9c4931cb5a75b7e8fb02971f57524da7a16dfec0d4d575327f/black-24.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9", size = 1571235, upload-time = "2024-03-15T19:45:27.77Z" },
-    { url = "https://files.pythonhosted.org/packages/46/5f/30398c5056cb72f883b32b6520ad00042a9d0454b693f70509867db03a80/black-24.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597", size = 1414926, upload-time = "2024-03-15T19:43:52.993Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/59/498885b279e890f656ea4300a2671c964acb6d97994ea626479c2e5501b4/black-24.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d", size = 1725920, upload-time = "2024-03-15T19:38:13.052Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b0/4bef40c808cc615187db983b75bacdca1c110a229d41ba9887549fac529c/black-24.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5", size = 1372608, upload-time = "2024-03-15T19:39:34.973Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/c6/1d174efa9ff02b22d0124c73fc5f4d4fb006d0d9a081aadc354d05754a13/black-24.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f", size = 1600822, upload-time = "2024-03-15T19:45:20.337Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/ed/704731afffe460b8ff0672623b40fce9fe569f2ee617c15857e4d4440a3a/black-24.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11", size = 1429987, upload-time = "2024-03-15T19:45:00.637Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/05/8dd038e30caadab7120176d4bc109b7ca2f4457f12eef746b0560a583458/black-24.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4", size = 1755319, upload-time = "2024-03-15T19:38:24.009Z" },
-    { url = "https://files.pythonhosted.org/packages/71/9d/e5fa1ff4ef1940be15a64883c0bb8d2fcf626efec996eab4ae5a8c691d2c/black-24.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5", size = 1385180, upload-time = "2024-03-15T19:39:37.014Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/ea/31770a7e49f3eedfd8cd7b35e78b3a3aaad860400f8673994bc988318135/black-24.3.0-py3-none-any.whl", hash = "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93", size = 201493, upload-time = "2024-03-15T19:35:41.572Z" },
-]
-
-[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -259,7 +229,7 @@ name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_version < '0'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
@@ -325,7 +295,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -442,7 +412,6 @@ dependencies = [
     { name = "appium-python-client" },
     { name = "behave" },
     { name = "behave-html-pretty-formatter" },
-    { name = "black" },
     { name = "flask", marker = "sys_platform == 'linux'" },
     { name = "imageio-ffmpeg" },
     { name = "mss" },
@@ -463,31 +432,38 @@ dependencies = [
     { name = "sure" },
 ]
 
+[package.dev-dependencies]
+lint = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "appium-python-client", marker = "python_full_version >= '3.10'", specifier = "==5.3.*" },
-    { name = "behave", marker = "python_full_version >= '3.10'", specifier = "==1.3.*" },
-    { name = "behave-html-pretty-formatter", marker = "python_full_version >= '3.10'", specifier = "==1.16.*" },
-    { name = "black", marker = "python_full_version >= '3.10'", specifier = "==24.3.*" },
-    { name = "flask", marker = "python_full_version >= '3.10' and sys_platform == 'linux'", specifier = "==3.0.*" },
-    { name = "imageio-ffmpeg", marker = "python_full_version >= '3.10'", specifier = "==0.6.*" },
-    { name = "mss", marker = "python_full_version >= '3.10'", specifier = "==9.*" },
-    { name = "numpy", marker = "python_full_version >= '3.10' and sys_platform == 'linux'", specifier = "==1.26.*" },
-    { name = "openpyxl", marker = "python_full_version >= '3.10'", specifier = "==3.1.*" },
-    { name = "playwright", marker = "python_full_version >= '3.10'", specifier = "==1.58.*" },
-    { name = "psutil", marker = "python_full_version >= '3.10'", specifier = "==5.9.*" },
-    { name = "pyautogui", marker = "python_full_version >= '3.10'", specifier = "==0.9.*" },
-    { name = "pygobject", marker = "python_full_version >= '3.10' and sys_platform == 'linux'", specifier = "==3.42.*" },
-    { name = "pylint", marker = "python_full_version >= '3.10'", specifier = "==3.2.*" },
-    { name = "pypdf", marker = "python_full_version >= '3.10'", specifier = "==6.5.*" },
-    { name = "pyperclip", marker = "python_full_version >= '3.10'", specifier = "==1.11.*" },
-    { name = "pyside6", marker = "python_full_version >= '3.10'", specifier = "==6.9.*" },
-    { name = "python-docx", marker = "python_full_version >= '3.10'", specifier = "==1.2.*" },
-    { name = "python-pptx", marker = "python_full_version >= '3.10'", specifier = "==1.0.*" },
-    { name = "pywin32", marker = "python_full_version >= '3.10' and sys_platform == 'win32'", specifier = "==305" },
-    { name = "requests", marker = "python_full_version >= '3.10'", specifier = "==2.32.*" },
-    { name = "sure", marker = "python_full_version >= '3.10'", specifier = "==2.0.*" },
+    { name = "appium-python-client", specifier = "==5.3.*" },
+    { name = "behave", specifier = "==1.3.*" },
+    { name = "behave-html-pretty-formatter", specifier = "==1.16.*" },
+    { name = "flask", marker = "sys_platform == 'linux'", specifier = "==3.0.*" },
+    { name = "imageio-ffmpeg", specifier = "==0.6.*" },
+    { name = "mss", specifier = "==9.*" },
+    { name = "numpy", marker = "sys_platform == 'linux'", specifier = "==1.26.*" },
+    { name = "openpyxl", specifier = "==3.1.*" },
+    { name = "playwright", specifier = "==1.58.*" },
+    { name = "psutil", specifier = "==5.9.*" },
+    { name = "pyautogui", specifier = "==0.9.*" },
+    { name = "pygobject", marker = "sys_platform == 'linux'", specifier = "==3.42.*" },
+    { name = "pylint", specifier = "==3.2.*" },
+    { name = "pypdf", specifier = "==6.5.*" },
+    { name = "pyperclip", specifier = "==1.11.*" },
+    { name = "pyside6", specifier = "==6.9.*" },
+    { name = "python-docx", specifier = "==1.2.*" },
+    { name = "python-pptx", specifier = "==1.0.*" },
+    { name = "pywin32", marker = "sys_platform == 'win32'", specifier = "==305" },
+    { name = "requests", specifier = "==2.32.*" },
+    { name = "sure", specifier = "==2.0.*" },
 ]
+
+[package.metadata.requires-dev]
+lint = [{ name = "ruff", specifier = ">=0.15.20" }]
 
 [[package]]
 name = "h11"
@@ -767,15 +743,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
@@ -820,15 +787,6 @@ wheels = [
 ]
 
 [[package]]
-name = "packaging"
-version = "26.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
 name = "parse"
 version = "1.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -848,15 +806,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1314,6 +1263,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/37/fa4718811f5f33cb43fbd9e78209b4105f86022965ae9ceed08ef23560a9/rubicon_objc-0.5.4.tar.gz", hash = "sha256:9ba5eb203df2b2e6c7f2d93f671b583ef5ea0f61b17a3ff44cd9c68673ad7916", size = 188492, upload-time = "2026-05-06T00:57:50.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/56/ba4987a64ceaae27f629644c4c52d2291eeab0755486d976c4bd1c781d86/rubicon_objc-0.5.4-py3-none-any.whl", hash = "sha256:f7c755388d5709d7079152892137b13bcc6b4bdd796c9f0d9b3a1eb5bea715c4", size = 64553, upload-time = "2026-05-06T00:57:49.032Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
part of https://github.com/opencloud-eu/desktop/issues/553

## Summary

* Add Ruff formatter to the project.
* Apply Ruff's default formatting while preserving existing string quotes (quote-style = "preserve"). 

### Ruff Formatter
Purpose: Automatically formats Python code to a consistent style.
It changes how the code looks, not how it behaves.

It fixes things like:
 *  Indentation
  * Spacing
  * Blank lines
  * Line wrapping
  * Quote style (if configured)

## Formatter commands

```bash
# Format files in place
uv run ruff format .
```

```bash
# Check whether files are already formatted
uv run ruff format . --check
```

```bash
# Show formatting differences without modifying files
uv run ruff format . --diff
```
