### PR TITLE
Fix account stuck in "Connecting" state after network switch

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -90,6 +90,18 @@ AccountState::AccountState(AccountPtr account)
         case NetworkInformation::Reachability::Site:
             [[fallthrough]];
         case NetworkInformation::Reachability::Unknown:
+            // Abort any running validator — its results are stale since the network changed.
+            // Without this, the guard in checkConnectivity() would skip the new attempt
+            // and leave the account stuck in "Connecting" state indefinitely.
+            if (_connectionValidator) {
+                _connectionValidator->disconnect(this);
+                _connectionValidator->deleteLater();
+                _connectionValidator.clear();
+            }
+            // Drop stale TCP connections from the old network interface so the
+            // upcoming connectivity check (and all subsequent requests) open
+            // fresh sockets on the new interface.
+            _account->accessManager()->clearConnectionCache();
             // the connection might not yet be established
             QTimer::singleShot(0, this, [this] { checkConnectivity(false); });
             break;
@@ -129,6 +141,13 @@ AccountState::AccountState(AccountPtr account)
             // will be rescheduled by a directory scan.
             _account->jobQueue()->clear();
             _queueGuard.unblock();
+        }
+
+        // Abort any running validator — captive portal state changed, so its results are stale.
+        if (_connectionValidator) {
+            _connectionValidator->disconnect(this);
+            _connectionValidator->deleteLater();
+            _connectionValidator.clear();
         }
 
         // A direct connect is not possible, because then the state parameter of `isBehindCaptivePortalChanged`

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -47,11 +47,17 @@ ConnectionValidator::ConnectionValidator(AccountPtr account, QObject *parent)
     : QObject(parent)
     , _account(account)
 {
-    // TODO: 6.0 abort validator on 5min timeout
+    // Hard timeout: abort the validator if it hasn't completed within 60 seconds.
+    // This prevents the account from getting stuck in "Connecting" state when
+    // a network change leaves HTTP requests hanging on a dead socket.
     auto timer = new QTimer(this);
-    timer->setInterval(30s);
-    connect(timer, &QTimer::timeout, this,
-        [this] { qCInfo(lcConnectionValidator) << u"ConnectionValidator" << _account->displayNameWithHost() << u"still running after" << _duration; });
+    timer->setSingleShot(true);
+    timer->setInterval(60s);
+    connect(timer, &QTimer::timeout, this, [this] {
+        qCWarning(lcConnectionValidator) << u"ConnectionValidator for" << _account->displayNameWithHost() << u"timed out after" << _duration;
+        _errors.append(tr("timeout"));
+        reportResult(Timeout);
+    });
     timer->start();
 }
 


### PR DESCRIPTION
When switching networks (e.g. WiFi → mobile hotspot), a running `ConnectionValidator`'s HTTP request could hang on the dead socket. The guard in `checkConnectivity()` would then block all subsequent reconnection attempts, leaving the account permanently stuck in "Connecting".

Two fixes:
- Abort any stale `ConnectionValidator` when reachability or captive-portal state changes, so a fresh validation can start immediately, and clear the access manager's connection cache so new requests open fresh sockets on the new interface.
- Add a 60-second hard timeout to `ConnectionValidator` to abort hung requests as a safety net.

Split out of #858 so it can be reviewed independently.

Tested on openSUSE Tumbleweed x86_64.
