### PR TITLE
chore(gui-test): implement vulture tool to detect dead code and remove those dead code

### DIFF
--- a/.woodpecker/python-lint.yaml
+++ b/.woodpecker/python-lint.yaml
@@ -31,3 +31,10 @@ steps:
       - cd test/gui
       - uv sync --only-group lint
       - make python-lint
+
+  - name: check-dead-code
+    image: *astral_uv_image
+    commands:
+      - cd test/gui
+      - uv sync --only-group lint
+      - make check-dead-code

--- a/test/gui/Makefile
+++ b/test/gui/Makefile
@@ -54,6 +54,10 @@ python-lint-fix: check-uv
 	uv run --no-sync ruff format .
 	uv run --no-sync ruff check . --fix
 
+.PHONY: check-dead-code
+check-dead-code: check-uv
+	uv run --no-sync vulture .
+
 .PHONY: gherkin-lint
 gherkin-lint:
 	gherlint -c ./config/.gherlintrc.json .

--- a/test/gui/helpers/FilesHelper.py
+++ b/test/gui/helpers/FilesHelper.py
@@ -63,15 +63,6 @@ def read_file_content(file):
         return f.read()
 
 
-def is_empty_sync_folder(folder):
-    ignore_files = ["Desktop.ini"]
-    for item in os.listdir(folder):
-        # do not count the hidden files as they are ignored by the client
-        if not item.startswith(".") and item not in ignore_files:
-            return False
-    return True
-
-
 def get_size_in_bytes(size):
     match = re.match(r"(\d+)((?: )?[KkMmGgBb]{0,2})?", str(size))
     units = ["b", "kb", "mb", "gb"]
@@ -93,10 +84,6 @@ def get_size_in_bytes(size):
                 return size_num * (multiplier**3)
 
     raise ValueError("Invalid size: " + size)
-
-
-def get_file_size(resource_path):
-    return os.stat(resource_path).st_size
 
 
 # temp paths created outside the temporary directory during the test

--- a/test/gui/helpers/SpaceHelper.py
+++ b/test/gui/helpers/SpaceHelper.py
@@ -44,11 +44,6 @@ def fetch_spaces(user=None, query=''):
     return response.json()['value']
 
 
-def get_project_spaces(user=None):
-    search_query = '$filter=driveType eq \'project\''
-    return fetch_spaces(query=search_query, user=user)
-
-
 def get_personal_space_id(user):
     search_query = '$filter=driveType eq \'personal\''
     space = fetch_spaces(query=search_query, user=user)

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -4,7 +4,7 @@ import time
 import urllib.request
 
 from pageObjects.SyncConnection import SyncConnection
-from helpers.ConfigHelper import get_config, is_linux, is_windows
+from helpers.ConfigHelper import get_config, is_windows
 from helpers.FilesHelper import sanitize_path
 from helpers.Utils import wait_for
 
@@ -49,9 +49,6 @@ else:
 # socket messages
 socket_messages = []
 SOCKET_CONNECT = None
-# Whether wait has been made or not after account is set up
-# This is useful for waiting only for the first time
-WAITED_AFTER_SYNC = False
 
 # File syncing in client has the following status
 SYNC_STATUS = {
@@ -165,16 +162,6 @@ def clear_socket_messages(resource=''):
         socket_messages = [msg for msg in socket_messages if msg not in resource_messages]
     else:
         socket_messages.clear()
-
-
-def close_socket_connection():
-    socket_messages.clear()
-    if SOCKET_CONNECT:
-        SOCKET_CONNECT.connected = False
-        if is_windows():
-            SOCKET_CONNECT.close_conn()
-        elif is_linux():
-            SOCKET_CONNECT._sock.close()
 
 
 def get_initial_sync_patterns():

--- a/test/gui/helpers/api/provisioning.py
+++ b/test/gui/helpers/api/provisioning.py
@@ -7,7 +7,6 @@ from helpers import UserHelper
 from helpers.api.utils import url_join
 
 
-created_groups = {}
 created_users = {}
 
 

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -14,8 +14,6 @@ class Activity:
         by=By.XPATH, selector="//page_tab[starts-with(@name, '{tab_name}')]"
     )
     LOCAL_ACTIVITY_FILTER_BUTTON = SimpleNamespace(by=By.NAME, selector="Filter")
-    LOCAL_ACTIVITY_FILTER_OPTION_SELECTOR = SimpleNamespace(by=By.NAME, selector=None)
-    LOCAL_ACTIVITY_TABLE = SimpleNamespace(by=By.NAME, selector="Local activity table")
     FILTER_BUTTON_SELECTED_STATE = SimpleNamespace(
         by=By.XPATH, selector="//*[contains(@name, '1 Filter')]"
     )

--- a/test/gui/pageObjects/EnterPassword.py
+++ b/test/gui/pageObjects/EnterPassword.py
@@ -7,13 +7,10 @@ from helpers.AppHelper import app
 
 
 class EnterPassword:
-    LOGIN_CONTAINER = SimpleNamespace(by=None, selector=None)
     LOGIN_USER_LABEL = SimpleNamespace(
         by=By.XPATH,
         selector="//filler[@name='Login required']//label[contains(@name, 'Connecting')]",
     )
-    USERNAME_BOX = SimpleNamespace(by=None, selector=None)
-    LOGOUT_BUTTON = SimpleNamespace(by=None, selector=None)
 
     def get_username(self):
         # Parse username from the login label:

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -74,12 +74,6 @@ class SyncConnection:
         SyncConnection.perform_action("Resume sync", "paused")
 
     @staticmethod
-    def menu_item_exists(menu_item):
-        obj = SyncConnection.MENU_ITEM.copy()
-        obj.update({"type": "QAction", "text": menu_item})
-        return object.exists(obj)
-
-    @staticmethod
     def choose_what_to_sync():
         SyncConnection.open_menu()
         SyncConnection.perform_action("Choose what to sync")

--- a/test/gui/pageObjects/Toolbar.py
+++ b/test/gui/pageObjects/Toolbar.py
@@ -10,7 +10,6 @@ from helpers.Utils import wait_for
 
 
 class Toolbar:
-    TOOLBAR_ROW = SimpleNamespace(by=None, selector=None)
     NAVIGATION_BAR = SimpleNamespace(by=By.XPATH, selector="//*[@name='Navigation bar']/..")
     ACCOUNT_TAB = SimpleNamespace(by=By.CLASS_NAME, selector="[page tab | {text}]")
     ADD_ACCOUNT_BUTTON = SimpleNamespace(by=By.CLASS_NAME, selector="[push button | Add Account]")

--- a/test/gui/pyproject.toml
+++ b/test/gui/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 [dependency-groups]
 lint = [
     "ruff>=0.15.20",
+    "vulture>=2.16",
 ]
 
 [tool.ruff]
@@ -64,3 +65,17 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "steps/*.py" = ["F811", "E501"]
 "steps/vfs_context.py" = ["F821"]
+
+[tool.vulture]
+ignore_names = [
+    "feature",
+    "step",
+    "after_scenario",
+    "before_feature",
+    "after_step",
+    "before_scenario",
+    "is_linux",
+    "close_conn",
+]
+
+exclude = [".venv", "__webdriver",]

--- a/test/gui/uv.lock
+++ b/test/gui/uv.lock
@@ -412,6 +412,7 @@ dependencies = [
 [package.dev-dependencies]
 lint = [
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -438,7 +439,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.15.20" }]
+lint = [
+    { name = "ruff", specifier = ">=0.15.20" },
+    { name = "vulture", specifier = ">=2.16" },
+]
 
 [[package]]
 name = "h11"
@@ -1393,6 +1397,18 @@ wheels = [
 [package.optional-dependencies]
 socks = [
     { name = "pysocks" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of https://github.com/opencloud-eu/desktop/issues/553 

[Vulture](https://github.com/jendrikseipp/vulture) is a static code analyzer that finds unused/dead code in Python projects.

Add vulture to the lint dependency group for dead code detection.

Confidence levels:
  - 100% → definitely unused
  - 80% → pretty sure unused
  - 60% → might be unused (noisy, not recommended)

```bash 
uv run vulture .
````

Since the codebase had minimal dead code after running vulture, all categories (variables, imports, functions, classes) are cleaned up in this single PR instead of splitting across multiple PRs.