### PR TITLE
fix: decode JWT segments as Base64url (RFC 7515)

### DIFF
--- a/src/libsync/creds/jwt.cpp
+++ b/src/libsync/creds/jwt.cpp
@@ -13,6 +13,9 @@
  */
 #include "jwt.h"
 
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(lcJwt, "sync.credentials.jwt", QtInfoMsg)
 
 OCC::JWT::JWT(const QByteArray &jwt)
 {
@@ -24,6 +27,7 @@ OCC::JWT::JWT(const QByteArray &jwt)
     auto parse = [](const QByteArray &part) {
         const auto decoded = QByteArray::fromBase64Encoding(part, QByteArray::Base64UrlEncoding | QByteArray::AbortOnBase64DecodingErrors);
         if (!decoded) {
+            qCWarning(lcJwt) << "Failed to Base64url-decode JWT segment, status:" << static_cast<int>(decoded.decodingStatus);
             return QJsonObject{};
         }
         return QJsonDocument::fromJson(*decoded).object();

--- a/src/libsync/creds/jwt.cpp
+++ b/src/libsync/creds/jwt.cpp
@@ -20,7 +20,14 @@ OCC::JWT::JWT(const QByteArray &jwt)
     if (parts.size() != 3) {
         return;
     }
-    auto parse = [](const QByteArray &part) { return QJsonDocument::fromJson(QByteArray::fromBase64(part)).object(); };
+    // JWT segments are Base64url encoded (RFC 7515 section 2), not standard Base64
+    auto parse = [](const QByteArray &part) {
+        const auto decoded = QByteArray::fromBase64Encoding(part, QByteArray::Base64UrlEncoding | QByteArray::AbortOnBase64DecodingErrors);
+        if (!decoded) {
+            return QJsonObject{};
+        }
+        return QJsonDocument::fromJson(*decoded).object();
+    };
     _header = parse(parts[0]);
     _payload = parse(parts[1]);
     _signauture = parts[2];

--- a/src/libsync/creds/jwt.h
+++ b/src/libsync/creds/jwt.h
@@ -15,9 +15,10 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>
+#include "opencloudsynclib.h"
 
 namespace OCC {
-class JWT
+class OPENCLOUD_SYNC_EXPORT JWT
 {
 public:
     /*

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -789,7 +789,7 @@ void AccountBasedOAuth::restore()
     auto idTokenJob = _account->credentialManager()->get(idTokenC());
     connect(idTokenJob, &CredentialJob::finished, this, [idTokenJob, this] {
         if (idTokenJob->error() == QKeychain::EntryNotFound) {
-            qCWarning(lcOauth) << u"idToken token token credential not found";
+            qCWarning(lcOauth) << u"idToken token credential not found";
         } else if (idTokenJob->error() != QKeychain::NoError) {
             Q_EMIT result(Error);
             return;

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -341,7 +341,8 @@ void OAuth::startAuthentication()
                     const QString refreshToken = getRequiredField(data, QStringLiteral("refresh_token"), &fieldsError).toString();
                     const QString tokenType = getRequiredField(data, QStringLiteral("token_type"), &fieldsError).toString().toLower();
                     const QUrl messageUrl = QUrl::fromEncoded(data[QStringLiteral("message_url")].toByteArray());
-                    auto idToken = IdToken(JWT(getRequiredField(data, QStringLiteral("id_token"), &fieldsError).toByteArray()).payload());
+                    const JWT jwt(getRequiredField(data, QStringLiteral("id_token"), &fieldsError).toByteArray());
+                    auto idToken = IdToken(jwt.payload());
 
 
                     auto reportError = [socket, this](const QString &errorReason) {
@@ -372,6 +373,8 @@ void OAuth::startAuthentication()
                         } else {
                             reportError(tr("Unknown Error"));
                         }
+                    } else if (!jwt.isValid()) {
+                        reportError(tr("The id_token could not be parsed"));
                     } else if (!idToken.aud().contains(_clientId)) {
                         reportError(tr("The audience of the id_token did not contain \"%1\"").arg(_clientId));
                     } else if (_idToken.isValid() && _idToken.sub() != idToken.sub()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(manual/icon_viewer)
 add_subdirectory(testutils)
 
 opencloud_add_test(JHash)
+opencloud_add_test(Jwt)
 
 opencloud_add_test(OwncloudPropagator)
 opencloud_add_test(OwnSql)

--- a/test/testjwt.cpp
+++ b/test/testjwt.cpp
@@ -1,0 +1,78 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "creds/jwt.h"
+
+using namespace OCC;
+
+namespace {
+QByteArray encodeSegment(const QJsonObject &obj)
+{
+    return QJsonDocument(obj).toJson(QJsonDocument::Compact).toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals);
+}
+}
+
+class TestJwt : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void testBase64UrlPayload()
+    {
+        // The base64url encoding of this payload contains both '-' and '_'
+        // ('?' and '>' each at a payload offset that is 2 mod 3, RFC 7515 section 2).
+        // A standard-alphabet Base64 decode drops these characters and corrupts
+        // every byte after them.
+        const QByteArray payloadPart = "eyJhdWQiOiJPcGVuQ2xvdWREZXNrdG9wIiwicGljIjoiaHR0cHM6Ly94LmV4YW1wbGUvYWE_dj0xIiwibm90ZSI6ImI-dGFnIn0";
+        QVERIFY(payloadPart.contains('_'));
+        QVERIFY(payloadPart.contains('-'));
+
+        const JWT jwt("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." + payloadPart + ".c2lnbmF0dXJl");
+        QVERIFY(jwt.isValid());
+        QCOMPARE(jwt.payload().value(QLatin1String("aud")).toString(), QStringLiteral("OpenCloudDesktop"));
+        QCOMPARE(jwt.payload().value(QLatin1String("pic")).toString(), QStringLiteral("https://x.example/aa?v=1"));
+        QCOMPARE(jwt.payload().value(QLatin1String("note")).toString(), QStringLiteral("b>tag"));
+    }
+
+    void testRoundTrip()
+    {
+        const QJsonObject header = {{QStringLiteral("alg"), QStringLiteral("RS256")}, {QStringLiteral("typ"), QStringLiteral("JWT")}};
+        const QJsonObject payload = {{QStringLiteral("aud"), QStringLiteral("OpenCloudDesktop")}, {QStringLiteral("pic"), QStringLiteral("https://x.example/aa?v=1")}};
+
+        const JWT jwt(encodeSegment(header) + "." + encodeSegment(payload) + ".c2lnbmF0dXJl");
+        QVERIFY(jwt.isValid());
+        QCOMPARE(jwt.header(), header);
+        QCOMPARE(jwt.payload(), payload);
+
+        const JWT reparsed(jwt.serialize());
+        QVERIFY(reparsed.isValid());
+        QCOMPARE(reparsed.payload(), payload);
+    }
+
+    void testMalformedToken()
+    {
+        QVERIFY(!JWT("").isValid());
+        QVERIFY(!JWT("onlyonepart").isValid());
+        QVERIFY(!JWT("two.parts").isValid());
+        QVERIFY(!JWT("not!base64.not!base64.c2lnbmF0dXJl").isValid());
+    }
+
+    void testStrictDecodingRejectsInvalidCharacters()
+    {
+        // An invalid character inside an otherwise valid payload segment: a
+        // permissive decode skips it and accepts a silently corrupted token,
+        // strict decoding must reject the whole segment.
+        const QByteArray payload = encodeSegment({{QStringLiteral("aud"), QStringLiteral("OpenCloudDesktop")}});
+        QVERIFY(JWT("eyJhbGciOiJSUzI1NiJ9." + payload + ".c2lnbmF0dXJl").isValid());
+        QVERIFY(!JWT("eyJhbGciOiJSUzI1NiJ9." + QByteArray(payload).insert(4, '!') + ".c2lnbmF0dXJl").isValid());
+    }
+};
+
+QTEST_GUILESS_MAIN(TestJwt)
+#include "testjwt.moc"

--- a/test/testoauth/testoauth.cpp
+++ b/test/testoauth/testoauth.cpp
@@ -409,6 +409,44 @@ private Q_SLOTS:
         test.test();
     }
 
+    void testUnparseableIdToken()
+    {
+        struct Test : OAuthTestCase
+        {
+            int corruptSegment = 0;
+
+            QString idToken() const override
+            {
+                // corrupt one segment with a character that is not valid base64url
+                QStringList parts = OAuthTestCase::idToken().split(QLatin1Char('.'));
+                parts[corruptSegment].insert(4, QLatin1Char('!'));
+                return parts.join(QLatin1Char('.'));
+            }
+
+            void browserReplyFinished() override
+            {
+                QCOMPARE(sender(), browserReply.data());
+                QCOMPARE(state, TokenAsked);
+                QCOMPARE(browserReply->error(), QNetworkReply::InternalServerError);
+                QVERIFY(QString::fromUtf8(browserReply->readAll()).contains(QStringLiteral("could not be parsed")));
+                browserReply->deleteLater();
+                replyToBrowserOk = true;
+            }
+
+            void oauthResult(OAuth::Result result, const QString &, const QString &) override
+            {
+                QCOMPARE(result, OAuth::Error);
+                gotAuthOk = true;
+            }
+        };
+        // a corrupted header (segment 0) and a corrupted payload (segment 1) must both be rejected
+        for (int segment : {0, 1}) {
+            Test test;
+            test.corruptSegment = segment;
+            test.test();
+        }
+    }
+
     // Test for https://github.com/owncloud/client/pull/6057
     void testCloseBrowserDontCrash()
     {

--- a/test/testoauth/testoauth.cpp
+++ b/test/testoauth/testoauth.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <QDesktopServices>
-#include <QtTest/QtTest>
 
 #include "common/asserts.h"
 #include "libsync/creds/httpcredentials.h"


### PR DESCRIPTION
Fixes #977

## What

`JWT::JWT()` decoded token segments with `QByteArray::fromBase64(part)`, which uses the standard Base64 alphabet. JWT segments are Base64url (RFC 7515 section 2). Qt's default `IgnoreBase64DecodingErrors` mode silently skips `-` and `_` as invalid characters and corrupts every byte after them. The payload then fails JSON parsing, `IdToken::aud()` returns an empty string, and OIDC login fails with a misleading "The audience of the id_token did not contain …" error. See #977 for the full analysis, including why the failure depends on token content and looked IdP-specific.

## Changes

Commit 1:

- `jwt.cpp`: decode segments with `Base64UrlEncoding | AbortOnBase64DecodingErrors` via `fromBase64Encoding`. A header or payload segment that is not valid base64url now yields an empty object, and so an invalid JWT, instead of silently corrupted claims. `serialize()` already used `Base64UrlEncoding`; only parsing was wrong.
- `test/testjwt.cpp` (new): regression tests. They cover a payload whose base64url encoding contains both `-` and `_`, a serialize/parse round-trip, structurally malformed tokens, and strict rejection of an invalid character inside an otherwise valid segment (the permissive decode wrongly accepted that case). Against the unpatched code, three of the four fail; with this change all pass.

Commit 2:

- `oauth.cpp`: an unparseable id_token previously fell through to the audience check and produced the misleading audience error. The token exchange handler now retains the parsed `JWT` and reports "The id_token could not be parsed" before checking the audience.
- `test/testoauth/testoauth.cpp`: new `testUnparseableIdToken` corrupts the header and payload segments in turn, and expects the parse error rather than a login or the audience message.

## Notes

- Strict Base64url decoding rejects tokens from IdPs that emit standard-alphabet `+` or `/` in JWT segments. RFC 7515 forbids those characters, but this is a behavior change for such non-compliant IdPs.
- Tested on Linux with Qt 6.8.2. I compiled the `testjwt` target standalone and ran it against both the patched and unpatched decoder; I did not run the full suite build in my environment.
