### PR TITLE
test(gui): configurable timeout for element search

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -55,6 +55,7 @@ steps:
 
   - name: build-client-for-ui-tests
     image: *build_image
+    pull: true # remove this once the nightlies run with the new build image
     commands:
       - mkdir -p build
       - cd build

--- a/.woodpecker/cache-python.yaml
+++ b/.woodpecker/cache-python.yaml
@@ -58,6 +58,7 @@ steps:
 
   - name: install-python-modules
     image: *build_image
+    pull: true # remove this once the nightlies run with the new build image
     commands:
       - . ./.woodpecker.env
       - if $PYTHON_CACHE_FOUND; then exit 0; fi
@@ -67,6 +68,7 @@ steps:
 
   - name: install-browsers
     image: *build_image
+    pull: true # remove this once the nightlies run with the new build image
     environment:
       PLAYWRIGHT_BROWSERS_PATH: /woodpecker/desktop/test/gui/.playwright
     commands:

--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -67,6 +67,7 @@ steps:
 
   - name: install-python-modules
     image: *build_image
+    pull: true # remove this once the nightlies run with the new build image
     environment:
       PLAYWRIGHT_BROWSERS_PATH: /woodpecker/desktop/test/gui/.playwright
     commands:
@@ -110,6 +111,7 @@ steps:
 
   - name: gui-tests
     image: *build_image
+    pull: true # remove this once the nightlies run with the new build image
     environment:
       # system cache environment variables
       PYTHONUSERBASE: /woodpecker/desktop/test/gui/.venv

--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -1,7 +1,7 @@
 import pyautogui
 import psutil
 import threading
-import requests
+import json
 from appium.webdriver import Remote, WebElement
 from appium.options.common.base import AppiumOptions
 from appium.webdriver.common.appiumby import AppiumBy as By
@@ -139,10 +139,8 @@ def set_implicit_wait(timeout):
     """
     session_id = app().session_id
     body = {'ms': timeout * 1000}
-    response = requests.request(
-        'POST',
+    response = request.post(
         f'{get_config("webdriver_url")}/session/{session_id}/timeouts/implicit_wait',
-        json=body,
-        timeout=get_config('max_timeout'),
+        json.dumps(body),
     )
     request.assert_http_status(response, 200, 'Failed to set implicit timeout')

--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -1,11 +1,13 @@
 import pyautogui
 import psutil
 import threading
+import requests
 from appium.webdriver import Remote, WebElement
 from appium.options.common.base import AppiumOptions
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.common.exceptions import WebDriverException, NoSuchElementException
 
+import helpers.api.http_helper as request
 from helpers.ConfigHelper import get_config, get_app_env
 from helpers.ElementHelper import get_element_center_xy
 from helpers.keys.keys_map import get_key
@@ -35,23 +37,32 @@ def native_send_keys(self, key):
     pyautogui.press(get_key(key))
 
 
-def find_element(self, by, selector):
+def find_element(self, by, selector, timeout=None):
     """
     Returns a visible element.
     Throws if no elements are found or if multiple visible elements are found.
     """
-    elements = self.find_elements(by, selector)
-    elements_count = len(elements)
-    if elements_count > 1:
-        visible_elements = [el for el in elements if el.is_displayed()]
-        if len(visible_elements) == 1:
-            return visible_elements.pop()
-        raise WebDriverException(
-            f'Found {elements_count} elements using "{by}={selector}"'
-        )
-    if elements_count == 0:
-        raise NoSuchElementException(f'No element found for "{by}={selector}"')
-    return elements[0]
+
+    if timeout is not None:
+        set_implicit_wait(timeout)
+
+    try:
+        elements = self.find_elements(by, selector)
+        elements_count = len(elements)
+        if elements_count > 1:
+            visible_elements = [el for el in elements if el.is_displayed()]
+            if len(visible_elements) == 1:
+                return visible_elements.pop()
+            raise WebDriverException(
+                f'Found {elements_count} elements using "{by}={selector}"'
+            )
+        if elements_count == 0:
+            raise NoSuchElementException(f'No element found for "{by}={selector}"')
+        return elements[0]
+    finally:
+        # reset implicit wait to default value
+        if timeout is not None:
+            set_implicit_wait(get_config('min_timeout'))
 
 
 def pause(self):
@@ -84,8 +95,11 @@ def create_app_session():
         f'{get_config("app_path")} -s {command_args} --logdebug',
     )
     options.set_capability('appium:environ', get_app_env())
-    app_driver = Remote(command_executor='http://localhost:4723', options=options)
-    app_driver.implicitly_wait = 10
+    options.set_capability('timeouts', { 'implicit': get_config('min_timeout') * 1000 })
+    app_driver = Remote(command_executor=get_config('webdriver_url'), options=options)
+    # NOTE: these methods to set implicit wait are not working:
+    # app_driver.implicitly_wait(5)
+    # app_driver.implicitly_wait = 5
 
 
 def close_and_kill_app():
@@ -117,3 +131,18 @@ def get_window_location():
         .location
     )
     return window['x'], window['y']
+
+
+def set_implicit_wait(timeout):
+    """
+    Set the implicit wait time for the current session.
+    """
+    session_id = app().session_id
+    body = {'ms': timeout * 1000}
+    response = requests.request(
+        'POST',
+        f'{get_config("webdriver_url")}/session/{session_id}/timeouts/implicit_wait',
+        json=body,
+        timeout=get_config('max_timeout'),
+    )
+    request.assert_http_status(response, 200, 'Failed to set implicit timeout')

--- a/test/gui/helpers/ConfigHelper.py
+++ b/test/gui/helpers/ConfigHelper.py
@@ -87,6 +87,7 @@ DEFAULT_PATH_CONFIG = {
     'files_for_upload': os.path.join(CURRENT_DIR.parent, 'files-for-upload'),
     # actual file path where the client stores the crash log.
     'crash_log_file': os.path.join(gettempdir(), CRASH_LOG_FILE),
+    'webdriver_url': 'http://localhost:4723',
 }
 
 # mutable configs

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -399,21 +399,6 @@ def wait_for_resource_to_have_sync_error(resource, resource_type):
     wait_for_resource_to_have_sync_status(resource, resource_type, SYNC_STATUS['ERROR'])
 
 
-# performing actions immediately after completing the sync from the server does not work
-# The test should wait for a while before performing the action
-# issue: https://github.com/owncloud/client/issues/8832
-def wait_for_client_to_be_ready():
-    global WAITED_AFTER_SYNC
-    if not WAITED_AFTER_SYNC:
-        time.sleep(get_config('min_timeout'))
-        WAITED_AFTER_SYNC = True
-
-
-def clear_waited_after_sync():
-    global WAITED_AFTER_SYNC
-    WAITED_AFTER_SYNC = False
-
-
 def perform_file_explorer_vfs_action(resource_path, action):
     if action == 'Free up space':
         make_online_only(resource_path)

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -99,6 +99,7 @@ class SyncConnection:
                     sync_path=get_config('currentUserSyncPath'),
                     status="success"
                 ),
+                timeout=get_config("lowest_timeout"),
             )
             return True
         except NoSuchElementException:
@@ -114,6 +115,7 @@ class SyncConnection:
                     sync_folder=sync_folder,
                     sync_path=get_config('currentUserSyncPath'),
                 ),
+                timeout=get_config("lowest_timeout"),
             )
             return True
         except NoSuchElementException:
@@ -142,6 +144,7 @@ class SyncConnection:
                 app().find_element(
                     SyncConnection.PERMISSION_ERROR_LABEL.by,
                     SyncConnection.PERMISSION_ERROR_LABEL.selector,
+                    timeout=get_config("lowest_timeout"),
                 )
                 return True
             except NoSuchElementException:

--- a/test/gui/pageObjects/Toolbar.py
+++ b/test/gui/pageObjects/Toolbar.py
@@ -116,6 +116,7 @@ class Toolbar:
             account = app().find_element(
                 Toolbar.ACCOUNT_TAB.by,
                 Toolbar.ACCOUNT_TAB.selector.format(text=account_label),
+                timeout=get_config("lowest_timeout"),
             )
         except NoSuchElementException:
             pass

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -9,7 +9,6 @@ from sure import ensure
 
 from helpers.SetupClientHelper import get_resource_path, get_temp_resource_path
 from helpers.SyncHelper import (
-    wait_for_client_to_be_ready,
     listen_sync_status_for_item,
 )
 from helpers.Utils import wait_for
@@ -72,14 +71,12 @@ def write_file(resource, content):
         f.write(content)
 
 
-def wait_and_write_file(path, content):
-    wait_for_client_to_be_ready()
+def write_file_to_sync_path(path, content):
     listen_sync_status_for_item(get_resource_path(path), 'FILE')
     write_file(path, content)
 
 
-def wait_and_try_to_write_file(resource, content):
-    wait_for_client_to_be_ready()
+def try_to_write_file(resource, content):
     listen_sync_status_for_item(get_resource_path(resource), 'FILE')
     try:
         write_file(resource, content)
@@ -120,7 +117,6 @@ def copy_resource(resource_type, source, destination, from_files_for_upload=Fals
     if source == destination and destination != '/':
         destination = add_copy_suffix(source, resource_type)
 
-    wait_for_client_to_be_ready()
     listen_sync_status_for_item(destination, resource_type)
     if resource_type == 'folder':
         return shutil.copytree(source, destination)
@@ -134,13 +130,11 @@ def move_resource(username, resource_type, source, destination, is_temp_folder=F
         destination = ''
     destination = get_resource_path(destination, username)
 
-    wait_for_client_to_be_ready()
     listen_sync_status_for_item(destination, resource_type)
     shutil.move(source, destination)
 
 
 def deleteResource(resource, resource_type):
-    wait_for_client_to_be_ready()
     listen_sync_status_for_item(resource, resource_type)
     resource_path = sanitize_path(get_resource_path(resource))
     if resource_type == 'file':
@@ -154,12 +148,11 @@ def deleteResource(resource, resource_type):
 )
 def step(context, username, filename):
     file = get_resource_path(filename, username)
-    wait_and_write_file(convert_path_separators_for_os(file), context.text)
+    write_file_to_sync_path(convert_path_separators_for_os(file), context.text)
 
 
 @When('user "{username}" creates a folder "{foldername}" inside the sync folder')
 def step(context, username, foldername):
-    wait_for_client_to_be_ready()
     create_folder(foldername, username)
 
 
@@ -190,7 +183,6 @@ def step(context, resource_type, resource_name):
 @When('the user renames a file "{source}" to "{destination}"')
 @When('the user renames a folder "{source}" to "{destination}"')
 def step(context, source, destination):
-    wait_for_client_to_be_ready()
     rename_file_folder(source, destination)
 
 
@@ -245,7 +237,7 @@ def step(context, resource_type, resource):
 @Given('the user has changed the content of local file "{filename}" to:')
 def step(context, filename):
     file_content = context.text
-    wait_and_write_file(get_resource_path(filename), file_content)
+    write_file_to_sync_path(get_resource_path(filename), file_content)
 
 
 @Then(
@@ -273,19 +265,19 @@ def step(context, filename):
 @When('the user overwrites the file "{resource}" with content "{content}"')
 def step(context, resource, content):
     resource = get_resource_path(resource)
-    wait_and_write_file(resource, content)
+    write_file_to_sync_path(resource, content)
 
 
 @When('the user tries to overwrite the file "|any|" with content "|any|"')
 def step(context, resource, content):
     resource = get_resource_path(resource)
-    wait_and_try_to_write_file(resource, content)
+    try_to_write_file(resource, content)
 
 
 @When('user "|any|" tries to overwrite the file "|any|" with content "|any|"')
 def step(context, user, resource, content):
     resource = get_resource_path(resource, user)
-    wait_and_try_to_write_file(resource, content)
+    try_to_write_file(resource, content)
 
 
 @When('the user deletes the {resource_type:ResourceType} "{resource_name}"')
@@ -297,7 +289,7 @@ def step(context, resource_type, resource_name):
 def step(context, username):
     for row in context.table:
         file = get_resource_path(row[0], username)
-        wait_and_write_file(file, '')
+        write_file_to_sync_path(file, '')
 
 
 @Given('the user has created a folder "{folder_name}" in temp folder')
@@ -414,7 +406,6 @@ def step(context, username, zip_file_name):
 
 @When('user "|any|" copies file "|any|" to temp folder')
 def step(context, username, source):
-    wait_for_client_to_be_ready()
     source_dir = get_resource_path(source, username)
     destination_dir = get_temp_resource_path(source)
     shutil.copy2(source_dir, destination_dir)
@@ -447,7 +438,6 @@ def step(context, resource_name, destination):
 
 @When('the user deletes the following files')
 def step(context):
-    wait_for_client_to_be_ready()
     for row in context.table:
         filename = row[0]
         deleteResource(filename, 'file')


### PR DESCRIPTION
Implement configurable timeout while using `find_element`. Default element search timeout is `5s`. Now we can configure it on the go.

Usage:
```py
driver.find_element('name', 'my button', 10)  # 10 seconds
```