### PR TITLE
Fix string that detects the openvfs mount in the system mount tab

### DIFF
--- a/src/plugins/vfs/openvfs/vfs_openvfs.cpp
+++ b/src/plugins/vfs/openvfs/vfs_openvfs.cpp
@@ -271,7 +271,7 @@ Result<void, QString> OpenVfsPluginFactory::prepare(const QString &path, const Q
             file.close();
             for (auto &line : lines) {
                 auto fields = line.split(' ');
-                if (fields.size() >= 9 && fields[8] == "fuse.openvfsfuse") {
+                if (fields.size() >= 9 && fields[8] == "fuse.openvfs") {
                     _fuseMountCache << QString::fromUtf8(parseMangledPath(fields[4]));
                 }
             }


### PR DESCRIPTION
We renamed openvfs at some point, so the string is different now. Now existing mounts get properly unmounted before the client tries to mount the fuse layer again.