### PR TITLE
fix: use a lowercase OAuth client identifier

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -320,7 +320,7 @@ QIcon Theme::wizardHeaderLogo() const
 
 QString Theme::oauthClientId() const
 {
-    return QStringLiteral("OpenCloudDesktop");
+    return QStringLiteral("openclouddesktop");
 }
 
 QString Theme::oauthClientSecret() const

--- a/test/testoauth/testoauth.cpp
+++ b/test/testoauth/testoauth.cpp
@@ -274,11 +274,11 @@ public:
           ],
           "at_hash": "jEL4ptHeYx4eQa847tOVoQ",
           "aud": [
-            "OpenCloudDesktop"
+            "openclouddesktop"
           ],
           "auth_time": 1737560752,
-          "azp": "OpenCloudDesktop",
-          "client_id": "OpenCloudDesktop",
+          "azp": "openclouddesktop",
+          "client_id": "openclouddesktop",
           "email": "admin@admin.admin",
           "email_verified": true,
           "exp": 1739884152,
@@ -292,8 +292,8 @@ public:
          */
         return QStringLiteral(
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-            "eyJhbXIiOlsicHdkIiwicG9wIiwiaHdrIiwidXNlciIsInBpbiIsIm1mYSJdLCJhdF9oYXNoIjoiakVMNHB0SGVZeDRlUWE4NDd0T1ZvUSIsImF1ZCI6WyJPcGVuQ2xvdWREZXNrdG9wIl0sIm"
-            "F1dGhfdGltZSI6MTczNzU2MDc1MiwiYXpwIjoiT3BlbkNsb3VkRGVza3RvcCIsImNsaWVudF9pZCI6Ik9wZW5DbG91ZERlc2t0b3AiLCJlbWFpbCI6ImFkbWluQGFkbWluLmFkbWluIiwiZW1h"
+            "eyJhbXIiOlsicHdkIiwicG9wIiwiaHdrIiwidXNlciIsInBpbiIsIm1mYSJdLCJhdF9oYXNoIjoiakVMNHB0SGVZeDRlUWE4NDd0T1ZvUSIsImF1ZCI6WyJvcGVuY2xvdWRkZXNrdG9wIl0sIm"
+            "F1dGhfdGltZSI6MTczNzU2MDc1MiwiYXpwIjoib3BlbmNsb3VkZGVza3RvcCIsImNsaWVudF9pZCI6Im9wZW5jbG91ZGRlc2t0b3AiLCJlbWFpbCI6ImFkbWluQGFkbWluLmFkbWluIiwiZW1h"
             "aWxfdmVyaWZpZWQiOnRydWUsImV4cCI6MTczOTg4NDE1MiwiaWF0IjoxNzM5ODgwNTUyLCJpc3MiOiJvYXV0aHRlc3Q6Ly9zb21lc2VydmVyL29wZW5jbG91ZCIsImp0aSI6ImUyZGI1ZjJkLT"
             "ZiY2MtNDJkNy1hMjBmLTQ2OTU1ZDdhYjZiNCIsIm5hbWUiOiJBZG1pbiIsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwic3ViIjoiZjRhMDRiNjItZTE3YS00YTk4LWJjYzYtNjMzNDVk"
             "ZWQ1YTI1In0.wj3NyKWaDhWWwui6lxGdmJEGUyqCsNYCRJFTbgIUeC4");


### PR DESCRIPTION
## Summary

OpenCloud Desktop currently advertises a static OAuth client identifier
`OpenCloudDesktop`. Some identity providers normalize client identifiers
when registering or looking up an OAuth client, so the ID token's
`aud`, `azp`, and `client_id` claims end up containing the normalized
form (e.g. `openclouddesktop`).

`src/libsync/creds/oauth.cpp` performs an exact, case-sensitive
audience check:

    idToken.aud().contains(_clientId)

With the mixed-case configured ID and a normalized audience, the
desktop rejects its own valid token after a successful authorization
and token exchange. This change normalizes the static client
identifier to `openclouddesktop` so the request and the audience check
agree on a single canonical value.

The audience comparison itself is intentionally not changed. Per
RFC 6749 §2.2 and OpenID Connect Core 1.0 §2 / §3.1.3.7, client
identifiers are opaque strings and the comparison must remain exact.

## Background and prior discussion

This PR is the client-side follow-up to
[kanidm/kanidm#4473](https://github.com/kanidm/kanidm/issues/4473),
where the case-sensitivity contract between the IdP and the client was
discussed. The conclusion of that discussion — that the client must
use the normalized value consistently — is what this PR implements.

This PR may also be relevant to
[opencloud-eu/desktop#217](https://github.com/opencloud-eu/desktop/issues/217),
which reports a different symptom (`no roles in user claims` from the
server-side proxy) but involves a deployment that registers
`OpenCloudDesktop` with Authelia. The same exact-match audience check
on the desktop is plausibly a contributor there, but the original
issue does not diagnose that, and this PR is not presented as a
resolution of #217 — only as a candidate mitigation to be verified
by a maintainer or the original reporter.

## Changes

- `src/libsync/theme.cpp`: `Theme::oauthClientId()` returns
  `"openclouddesktop"` instead of `"OpenCloudDesktop"`.
- `test/testoauth/testoauth.cpp`: the synthetic ID token's `aud`,
  `azp`, and `client_id` claims are updated to match.

## Operator notes

Operators of OpenCloud Desktop deployments must register
`openclouddesktop` with their identity provider. Existing
deployments that registered `OpenCloudDesktop` should update the
client identifier on the IdP side to match, otherwise the audience
mismatch described above will continue to occur. Both spellings
can be registered in parallel during a transition window if desired.

## References

- RFC 6749, Section 2.2 (client identifier)
- OpenID Connect Core 1.0, Section 2 (`azp` claim) and
  Section 3.1.3.7 (ID Token validation)
- kanidm/kanidm#4473 — original report
- opencloud-eu/desktop#217 — possibly related, not resolved by
  this PR
