### PR TITLE
test(gui): fix flaky spaces test suite

### DIFF
--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -36,9 +36,11 @@ workspace:
 matrix:
   include:
     - MATRIX_NAME: gui-tests-1
-      SUITES: 'features/activity features/add-account features/delete-files-folders features/edit-files features/login-logout features/move-files-folders'
+      SUITES: 'features/add-account features/delete-files-folders features/edit-files features/login-logout features/move-files-folders'
     - MATRIX_NAME: gui-tests-2
-      SUITES: 'features/remove-account-connection features/spaces features/sync-resources features/tabs-settings features/vfs'
+      SUITES: 'features/activity features/remove-account-connection features/spaces features/sync-edge-cases features/tabs-settings'
+    - MATRIX_NAME: gui-tests-3
+      SUITES: 'features/sync-resources features/vfs'
 
 steps:
   - name: restore-python-cache

--- a/test/gui/Makefile
+++ b/test/gui/Makefile
@@ -46,7 +46,7 @@ run-atpsi-webdriver: check-uv
 
 .PHONY: python-lint
 python-lint: check-uv
-	uv run --no-sync ruff format . --check
+	uv run --no-sync ruff format . --diff
 
 .PHONY: python-lint-fix
 python-lint-fix: check-uv

--- a/test/gui/features/sync-edge-cases/syncResources.feature
+++ b/test/gui/features/sync-edge-cases/syncResources.feature
@@ -1,0 +1,221 @@
+Feature: Syncing files
+    As a user
+    I want to be able to sync the files and folders to/from the server
+    so that my files are always up to date
+
+    Background:
+        Given user "Alice" has been created in the server with default attributes
+
+    @issue-9733 @skip
+    Scenario: Syncing a file from the server and creating a conflict
+        Given user "Alice" has uploaded file with content "server content" to "/conflict.txt" in the server
+        And user "Alice" has set up a client with default settings
+        And the user has paused the file sync
+        And the user has changed the content of local file "conflict.txt" to:
+            """
+            client content
+            """
+        And user "Alice" has uploaded file with content "changed server content" to "/conflict.txt" in the server
+        And the user has waited for "5" seconds
+        When the user resumes the file sync on the client
+        And the user opens the activity tab
+        And the user selects "Not Synced" tab in the activity
+        Then the table of conflict warnings should include file "conflict.txt"
+        And the file "conflict.txt" should exist on the file system with the following content
+            """
+            changed server content
+            """
+        And a conflict file for "conflict.txt" should exist on the file system with the following content
+            """
+            client content
+            """
+
+    @skipOnWindows
+    Scenario Outline: Syncing a folder having space at the end (Linux only)
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder <foldername> inside the sync folder
+        And the user waits for folder <foldername> to be synced
+        Then as "Alice" folder <foldername> should exist in the server
+        Examples:
+            | foldername                  |
+            | "folder with space at end " |
+
+    @skipOnLinux @skip
+    Scenario: Try to sync files having space at the end (Windows only)
+        Given user "Alice" has uploaded file with content "lorem epsum" to "trailing-space.txt " in the server
+        And user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder "folder with space at end " inside the sync folder
+        And the user force syncs the files
+        And the user opens the activity tab
+        And the user selects "Not Synced" tab in the activity
+        Then the file "trailing-space.txt " should be ignored
+        And the file "folder with space at end " should be ignored
+
+    @issue-9281 @smoke
+    Scenario: Verify that you can create a subfolder with long name(~220 characters)
+        Given user "Alice" has created a folder "Folder1" inside the sync folder
+        And user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" inside the sync folder
+        And the user waits for folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" to be synced
+        Then the folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" should exist on the file system
+        And as "Alice" folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" should exist in the server
+
+
+    Scenario Outline: Sync long nested folder
+        Given user "Alice" has created folder "<foldername>" in the server
+        And user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder "<foldername>/<foldername>" inside the sync folder
+        And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>" inside the sync folder
+        And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>/<foldername>" inside the sync folder
+        And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" inside the sync folder
+        And the user waits for folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" to be synced
+        Then as "Alice" folder "<foldername>/<foldername>" should exist in the server
+        And as "Alice" folder "<foldername>/<foldername>/<foldername>" should exist in the server
+        And as "Alice" folder "<foldername>/<foldername>/<foldername>/<foldername>" should exist in the server
+        And as "Alice" folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" should exist in the server
+        Examples:
+            | foldername                                                      |
+            | An empty folder which name is obviously more than 59 characters |
+
+    @smoke
+    Scenario Outline: File with long name can be synced
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
+            """
+            test content
+            """
+        And the user waits for file "<filename>" to be synced
+        Then as "Alice" file "<filename>" should exist in the server
+        Examples:
+            | filename                                                                                                                                                                                                                     |
+            | thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIs.txt |
+
+
+    Scenario: File with spaces in the name can sync
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "file with space.txt" with the following content inside the sync folder
+            """
+            test contents
+            """
+        And the user waits for file "file with space.txt" to be synced
+        Then as "Alice" file "file with space.txt" should exist in the server
+
+
+    Scenario: extract a zip file in the sync folder
+        Given the user has created a zip file "archive.zip" with the following resources in the temp folder
+            | resource  | type   | content    |
+            | folder1   | folder |            |
+            | folder2   | folder |            |
+            | file1.txt | file   | Test file1 |
+            | file2.txt | file   | Test file2 |
+        And user "Alice" has set up a client with default settings
+        When user "Alice" moves file "archive.zip" from the temp folder into the sync folder
+        And user "Alice" unzips the zip file "archive.zip" inside the sync root
+        And the user waits for the files to sync
+        Then as "Alice" folder "folder1" should exist in the server
+        And as "Alice" folder "folder2" should exist in the server
+        And as "Alice" the file "file1.txt" should have the content "Test file1" in the server
+        And as "Alice" the file "file2.txt" should have the content "Test file2" in the server
+
+    @skipOnWindows
+    Scenario: sync remote folder to a local sync folder having special characters
+        Given user "Alice" has created folder "~`!@#$^&()-_=+{[}];',)" in the server
+        And user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has created folder "test-folder" in the server
+        And user "Alice" has created folder "test-folder/sub-folder1" in the server
+        And user "Alice" has created folder "test-folder/sub-folder2" in the server
+        And user "Alice" has created folder "~test%" in the server
+        And the user has created a folder "~`!@#$^&()-_=+{[}];',)PRN%" in temp folder
+        And the user has started the client
+        And the user has entered the following account information:
+            | server   | %local_server% |
+            | user     | Alice          |
+            | password | 1234           |
+        When the user selects manual sync folder option in advanced section
+        And the user sets the temp folder "~`!@#$^&()-_=+{[}];',)PRN%" as local sync path in sync connection wizard
+        And the user selects "Personal" space in sync connection wizard
+        And the user selects only the following folders to sync:
+            | folder                  |
+            | ~`!@#$^&()-_=+{[}];',)  |
+            | simple-folder           |
+            | test-folder/sub-folder2 |
+        Then the folder "~`!@#$^&()-_=+{[}];',)" should exist on the file system
+        And the folder "simple-folder" should exist on the file system
+        But the folder "~test%" should not exist on the file system
+        When user "Alice" deletes the folder "simple-folder" in the server
+        And the user waits for the files to sync
+        Then the folder "simple-folder" should not exist on the file system
+        And the folder "test-folder/sub-folder2" should exist on the file system
+        And the folder "test-folder/sub-folder1" should not exist on the file system
+
+
+    Scenario: Syncing a local folder having special characters to the server
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" inside the sync folder
+        And the user waits for folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" to be synced
+        Then as "Alice" folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" should exist in the server
+
+
+    Scenario Outline: File with long multi-byte characters name can be synced (76 characters, 255 bytes including extension)
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
+            """
+            test content
+            """
+        And the user waits for file "<filename>" to be synced
+        Then as "Alice" file "<filename>" should exist in the server
+        Examples:
+            | filename                                                                    |
+            | 𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺abôǣฎพฒฆ๘ตกกผพฒณญไใๅำ๊๒๔๗๘รศฬอฮ.txt |
+
+
+    Scenario: Sync a received shared folder with Viewer permission role
+        Given user "Brian" has been created in the server with default attributes
+        And user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has uploaded file with content "test content" to "simple-folder/uploaded-lorem.txt" in the server
+        And user "Alice" has sent the following resource share invitation:
+            | resource        | simple-folder |
+            | sharee          | Brian         |
+            | permissionsRole | Viewer        |
+        And user "Brian" has set up a client with space "Shares"
+        When user "Brian" creates a folder "simple-folder/sub-folder" inside the sync folder
+        Then the folder "simple-folder/sub-folder" should exist on the file system
+        But the following error message should appear in the client
+            """
+            simple-folder/sub-folder: Not allowed because you don't have permission to add subfolders to that folder
+            """
+        When the user copies file "simple.pdf" from outside the sync folder to "simple-folder/simple.pdf" in the sync folder
+        Then the file "simple-folder/simple.pdf" should exist on the file system
+        But the following error message should appear in the client
+            """
+            simple-folder/simple.pdf: Not allowed because you don't have permission to add files in that folder
+            """
+        And as "Brian" folder "simple-folder/sub-folder" should not exist in the server
+        And as "Brian" file "simple-folder/simple.pdf" should not exist in the server
+        When the user opens the activity tab
+        And the user selects "Not Synced" tab in the activity
+        Then the following activities should be displayed in not synced table
+            | resource                 | status      | account                              |
+            | simple-folder/sub-folder | Blacklisted | Brian Murphy@%local_server_hostname% |
+            | simple-folder/simple.pdf | Blacklisted | Brian Murphy@%local_server_hostname% |
+
+
+	Scenario: Sync a received shared folder with Editor permission role
+        Given user "Brian" has been created in the server with default attributes
+        And user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has uploaded file with content "test content" to "simple-folder/uploaded-lorem.txt" in the server
+        And user "Alice" has sent the following resource share invitation:
+            | resource        | simple-folder |
+            | sharee          | Brian         |
+            | permissionsRole | Editor        |
+        And user "Brian" has set up a client with space "Shares"
+        When user "Brian" creates a folder "simple-folder/sub-folder" inside the sync folder
+        And the user copies file "simple.pdf" from outside the sync folder to "simple-folder/simple.pdf" in the sync folder
+        And the user overwrites the file "simple-folder/uploaded-lorem.txt" with content "overwrite openCloud test text file"
+        And the user waits for the files to sync
+        And the user waits for folder "simple-folder/sub-folder" to be synced
+        Then the folder "simple-folder/sub-folder" should exist on the file system
+        And the file "simple-folder/simple.pdf" should exist on the file system
+        And as "Brian" folder "Shares/simple-folder/sub-folder" should exist in the server
+        And as "Brian" file "Shares/simple-folder/simple.pdf" should exist in the server
+        And as "Brian" the file "Shares/simple-folder/uploaded-lorem.txt" should have the content "overwrite openCloud test text file" in the server

--- a/test/gui/features/sync-resources/syncResources.feature
+++ b/test/gui/features/sync-resources/syncResources.feature
@@ -1,7 +1,7 @@
 Feature: Syncing files
     As a user
-    I want to be able to sync my local folders to to my opencloud server
-    so that I dont have to upload and download files manually
+    I want to be able to sync the files and folders to/from the server
+    so that my files are always up to date
 
     Background:
         Given user "Alice" has been created in the server with default attributes
@@ -32,30 +32,6 @@ Feature: Syncing files
             """
         And the folder "simple-folder" should exist on the file system
         And the folder "large-folder" should exist on the file system
-
-    @issue-9733 @skip
-    Scenario: Syncing a file from the server and creating a conflict
-        Given user "Alice" has uploaded file with content "server content" to "/conflict.txt" in the server
-        And user "Alice" has set up a client with default settings
-        And the user has paused the file sync
-        And the user has changed the content of local file "conflict.txt" to:
-            """
-            client content
-            """
-        And user "Alice" has uploaded file with content "changed server content" to "/conflict.txt" in the server
-        And the user has waited for "5" seconds
-        When the user resumes the file sync on the client
-        And the user opens the activity tab
-        And the user selects "Not Synced" tab in the activity
-        Then the table of conflict warnings should include file "conflict.txt"
-        And the file "conflict.txt" should exist on the file system with the following content
-            """
-            changed server content
-            """
-        And a conflict file for "conflict.txt" should exist on the file system with the following content
-            """
-            client content
-            """
 
     @skipOnWindows
     Scenario: Sync all is selected by default
@@ -164,27 +140,6 @@ Feature: Syncing files
             | "myFolder"                                                               |
             | "really long folder name with some spaces and special char such as $%ñ&" |
 
-    @skipOnWindows
-    Scenario Outline: Syncing a folder having space at the end (Linux only)
-        Given user "Alice" has set up a client with default settings
-        When user "Alice" creates a folder <foldername> inside the sync folder
-        And the user waits for folder <foldername> to be synced
-        Then as "Alice" folder <foldername> should exist in the server
-        Examples:
-            | foldername                  |
-            | "folder with space at end " |
-
-    @skipOnLinux @skip
-    Scenario: Try to sync files having space at the end (Windows only)
-        Given user "Alice" has uploaded file with content "lorem epsum" to "trailing-space.txt " in the server
-        And user "Alice" has set up a client with default settings
-        When user "Alice" creates a folder "folder with space at end " inside the sync folder
-        And the user force syncs the files
-        And the user opens the activity tab
-        And the user selects "Not Synced" tab in the activity
-        Then the file "trailing-space.txt " should be ignored
-        And the file "folder with space at end " should be ignored
-
     @smoke
     Scenario: Many subfolders can be synced
         Given user "Alice" has created folder "parent" in the server
@@ -246,15 +201,6 @@ Feature: Syncing files
         And as "Alice" folder "original (Copy)" should exist in the server
         And as "Alice" the file "original (Copy)/localFile.txt" should have the content "test content" in the server
 
-    @issue-9281 @smoke
-    Scenario: Verify that you can create a subfolder with long name(~220 characters)
-        Given user "Alice" has created a folder "Folder1" inside the sync folder
-        And user "Alice" has set up a client with default settings
-        When user "Alice" creates a folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" inside the sync folder
-        And the user waits for folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" to be synced
-        Then the folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" should exist on the file system
-        And as "Alice" folder "Folder1/thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks-thisIsAVeryLongFolderNameToCheckThatItWorks" should exist in the server
-
     @smoke
     Scenario: Verify pre existing folders in local (Desktop client) are copied over to the server
         Given user "Alice" has created a folder "Folder1" inside the sync folder
@@ -277,23 +223,6 @@ Feature: Syncing files
         And the user selects "Not Synced" tab in the activity
         Then the file "Folder1/a\\a.txt" should exist on the file system
         And the file "Folder1/a\\a.txt" should be blacklisted
-
-
-    Scenario Outline: Sync long nested folder
-        Given user "Alice" has created folder "<foldername>" in the server
-        And user "Alice" has set up a client with default settings
-        When user "Alice" creates a folder "<foldername>/<foldername>" inside the sync folder
-        And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>" inside the sync folder
-        And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>/<foldername>" inside the sync folder
-        And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" inside the sync folder
-        And the user waits for folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" to be synced
-        Then as "Alice" folder "<foldername>/<foldername>" should exist in the server
-        And as "Alice" folder "<foldername>/<foldername>/<foldername>" should exist in the server
-        And as "Alice" folder "<foldername>/<foldername>/<foldername>/<foldername>" should exist in the server
-        And as "Alice" folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" should exist in the server
-        Examples:
-            | foldername                                                      |
-            | An empty folder which name is obviously more than 59 characters |
 
     @skipOnWindows @smoke
     Scenario: Invalid system names are synced (Linux only)
@@ -373,34 +302,11 @@ Feature: Syncing files
         And as "Alice" file "simple.xlsx" should exist in the server
 
     @smoke
-    Scenario Outline: File with long name can be synced
-        Given user "Alice" has set up a client with default settings
-        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
-            """
-            test content
-            """
-        And the user waits for file "<filename>" to be synced
-        Then as "Alice" file "<filename>" should exist in the server
-        Examples:
-            | filename                                                                                                                                                                                                                     |
-            | thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIs.txt |
-
-    @smoke
     Scenario: Syncing file of 1 GB size
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "newfile.txt" with size "1GB" inside the sync folder
         And the user waits for file "newfile.txt" to be synced
         Then as "Alice" file "newfile.txt" should exist in the server
-
-
-    Scenario: File with spaces in the name can sync
-        Given user "Alice" has set up a client with default settings
-        When user "Alice" creates a file "file with space.txt" with the following content inside the sync folder
-            """
-            test contents
-            """
-        And the user waits for file "file with space.txt" to be synced
-        Then as "Alice" file "file with space.txt" should exist in the server
 
 
     Scenario: Syncing folders each having large number of files
@@ -437,61 +343,6 @@ Feature: Syncing files
         And for user "Alice" sync folder "Personal" should not be displayed
         And for user "Alice" sync folder "Shares" should not be displayed
 
-
-    Scenario: extract a zip file in the sync folder
-        Given the user has created a zip file "archive.zip" with the following resources in the temp folder
-            | resource  | type   | content    |
-            | folder1   | folder |            |
-            | folder2   | folder |            |
-            | file1.txt | file   | Test file1 |
-            | file2.txt | file   | Test file2 |
-        And user "Alice" has set up a client with default settings
-        When user "Alice" moves file "archive.zip" from the temp folder into the sync folder
-        And user "Alice" unzips the zip file "archive.zip" inside the sync root
-        And the user waits for the files to sync
-        Then as "Alice" folder "folder1" should exist in the server
-        And as "Alice" folder "folder2" should exist in the server
-        And as "Alice" the file "file1.txt" should have the content "Test file1" in the server
-        And as "Alice" the file "file2.txt" should have the content "Test file2" in the server
-
-    @skipOnWindows
-    Scenario: sync remote folder to a local sync folder having special characters
-        Given user "Alice" has created folder "~`!@#$^&()-_=+{[}];',)" in the server
-        And user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has created folder "test-folder" in the server
-        And user "Alice" has created folder "test-folder/sub-folder1" in the server
-        And user "Alice" has created folder "test-folder/sub-folder2" in the server
-        And user "Alice" has created folder "~test%" in the server
-        And the user has created a folder "~`!@#$^&()-_=+{[}];',)PRN%" in temp folder
-        And the user has started the client
-        And the user has entered the following account information:
-            | server   | %local_server% |
-            | user     | Alice          |
-            | password | 1234           |
-        When the user selects manual sync folder option in advanced section
-        And the user sets the temp folder "~`!@#$^&()-_=+{[}];',)PRN%" as local sync path in sync connection wizard
-        And the user selects "Personal" space in sync connection wizard
-        And the user selects only the following folders to sync:
-            | folder                  |
-            | ~`!@#$^&()-_=+{[}];',)  |
-            | simple-folder           |
-            | test-folder/sub-folder2 |
-        Then the folder "~`!@#$^&()-_=+{[}];',)" should exist on the file system
-        And the folder "simple-folder" should exist on the file system
-        But the folder "~test%" should not exist on the file system
-        When user "Alice" deletes the folder "simple-folder" in the server
-        And the user waits for the files to sync
-        Then the folder "simple-folder" should not exist on the file system
-        And the folder "test-folder/sub-folder2" should exist on the file system
-        And the folder "test-folder/sub-folder1" should not exist on the file system
-
-
-    Scenario: Syncing a local folder having special characters to the server
-        Given user "Alice" has set up a client with default settings
-        When user "Alice" creates a folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" inside the sync folder
-        And the user waits for folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" to be synced
-        Then as "Alice" folder "~`!@#$^&()-_=+{[}];',)💥🫨❤️‍🔥" should exist in the server
-
     @issue-11814
     Scenario: Remove folder sync connection (Personal Space)
         Given user "Alice" has created folder "simple-folder" in the server
@@ -500,71 +351,6 @@ Feature: Syncing files
         Then for user "Alice" sync folder "Personal" should not be displayed
         And the folder "simple-folder" should exist on the file system
         And as "Alice" folder "simple-folder" should exist in the server
-
-
-    Scenario: Sync a received shared folder with Viewer permission role
-        Given user "Brian" has been created in the server with default attributes
-        And user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has uploaded file with content "test content" to "simple-folder/uploaded-lorem.txt" in the server
-        And user "Alice" has sent the following resource share invitation:
-            | resource        | simple-folder |
-            | sharee          | Brian         |
-            | permissionsRole | Viewer        |
-        And user "Brian" has set up a client with space "Shares"
-        When user "Brian" creates a folder "simple-folder/sub-folder" inside the sync folder
-        Then the folder "simple-folder/sub-folder" should exist on the file system
-        But the following error message should appear in the client
-            """
-            simple-folder/sub-folder: Not allowed because you don't have permission to add subfolders to that folder
-            """
-        When the user copies file "simple.pdf" from outside the sync folder to "simple-folder/simple.pdf" in the sync folder
-        Then the file "simple-folder/simple.pdf" should exist on the file system
-        But the following error message should appear in the client
-            """
-            simple-folder/simple.pdf: Not allowed because you don't have permission to add files in that folder
-            """
-        And as "Brian" folder "simple-folder/sub-folder" should not exist in the server
-        And as "Brian" file "simple-folder/simple.pdf" should not exist in the server
-        When the user opens the activity tab
-        And the user selects "Not Synced" tab in the activity
-        Then the following activities should be displayed in not synced table
-            | resource                 | status      | account                              |
-            | simple-folder/sub-folder | Blacklisted | Brian Murphy@%local_server_hostname% |
-            | simple-folder/simple.pdf | Blacklisted | Brian Murphy@%local_server_hostname% |
-
-
-    Scenario Outline: File with long multi-byte characters name can be synced (76 characters, 255 bytes including extension)
-        Given user "Alice" has set up a client with default settings
-        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
-            """
-            test content
-            """
-        And the user waits for file "<filename>" to be synced
-        Then as "Alice" file "<filename>" should exist in the server
-        Examples:
-            | filename                                                                    |
-            | 𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺𒁻𒁼𒁾𒁿𒁰𒁱𒁲𒁳𒁴𒁵𒁶𒁷𒁸𒁹𒁺abôǣฎพฒฆ๘ตกกผพฒณญไใๅำ๊๒๔๗๘รศฬอฮ.txt |
-
-
-	Scenario: Sync a received shared folder with Editor permission role
-        Given user "Brian" has been created in the server with default attributes
-        And user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has uploaded file with content "test content" to "simple-folder/uploaded-lorem.txt" in the server
-        And user "Alice" has sent the following resource share invitation:
-            | resource        | simple-folder |
-            | sharee          | Brian         |
-            | permissionsRole | Editor        |
-        And user "Brian" has set up a client with space "Shares"
-        When user "Brian" creates a folder "simple-folder/sub-folder" inside the sync folder
-        And the user copies file "simple.pdf" from outside the sync folder to "simple-folder/simple.pdf" in the sync folder
-        And the user overwrites the file "simple-folder/uploaded-lorem.txt" with content "overwrite openCloud test text file"
-        And the user waits for the files to sync
-        And the user waits for folder "simple-folder/sub-folder" to be synced
-        Then the folder "simple-folder/sub-folder" should exist on the file system
-        And the file "simple-folder/simple.pdf" should exist on the file system
-        And as "Brian" folder "Shares/simple-folder/sub-folder" should exist in the server
-        And as "Brian" file "Shares/simple-folder/simple.pdf" should exist in the server
-        And as "Brian" the file "Shares/simple-folder/uploaded-lorem.txt" should have the content "overwrite openCloud test text file" in the server
 
     @skipOnWindows @smoke
     Scenario: Unselected subfolders are excluded from local sync

--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -11,6 +11,7 @@ import helpers.api.http_helper as request
 from helpers.ConfigHelper import get_config, get_app_env
 from helpers.ElementHelper import get_element_center_xy
 from helpers.keys.keys_map import get_key
+from helpers.Utils import wait_for
 
 
 def native_click(self, **kwargs):
@@ -122,6 +123,21 @@ def close_and_kill_app():
 
     # Reset driver for reuse
     app_driver = None
+
+
+def wait_until_app_terminated():
+    def check_app():
+        for process in psutil.process_iter(['exe']):
+            if process.info['exe'] == get_config("app_path"):
+                return False
+        return True
+
+    terminated = wait_for(
+        lambda: check_app(),
+        get_config('max_timeout'),
+    )
+    if not terminated:
+        raise ValueError("Desktop client did not terminate within the timeout period.")
 
 
 def get_window_location():

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -324,12 +324,12 @@ def wait_for_resource_to_sync(
     )
 
 
-def wait_for_initial_sync_to_complete(path, check_queued=True):
+def wait_for_initial_sync_to_complete(path, force_sync=True, check_queued=True):
     wait_for_resource_to_sync(
         path,
         'FOLDER',
         get_initial_sync_patterns(),
-        True,
+        force_sync,
         check_queued,
     )
 

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -147,7 +147,7 @@ class SyncConnection:
                     timeout=get_config("lowest_timeout"),
                 )
                 return True
-            except NoSuchElementException:
+            except (NoSuchElementException, WebDriverException):
                 return False
 
         status = wait_for(

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -86,7 +86,9 @@ def step(context):
         listen_sync_status_for_item(sync_paths[username])
         enter_password.login_after_setup(username, password)
         # wait for files to sync
-        wait_for_initial_sync_to_complete(sync_paths[username], force_sync=False, check_queued=False)
+        wait_for_initial_sync_to_complete(
+            sync_paths[username], force_sync=False, check_queued=False
+        )
     Toolbar.wait_toolbar_enabled()
 
 

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -86,7 +86,7 @@ def step(context):
         listen_sync_status_for_item(sync_paths[username])
         enter_password.login_after_setup(username, password)
         # wait for files to sync
-        wait_for_initial_sync_to_complete(sync_paths[username], False)
+        wait_for_initial_sync_to_complete(sync_paths[username], force_sync=False, check_queued=False)
     Toolbar.wait_toolbar_enabled()
 
 

--- a/test/gui/steps/account_context.py
+++ b/test/gui/steps/account_context.py
@@ -23,7 +23,7 @@ from helpers.SyncHelper import (
 from helpers.UserHelper import get_password_for_user
 from helpers.ConfigHelper import get_config
 from helpers.TableParser import table_rows_hash
-from helpers.AppHelper import close_and_kill_app
+from helpers.AppHelper import close_and_kill_app, wait_until_app_terminated
 from helpers.FilesHelper import convert_path_separators_for_os
 
 
@@ -219,6 +219,7 @@ def step(context):
 @When('the user quits the client')
 def step(context):
     Toolbar.quit_opencloud()
+    wait_until_app_terminated()
     close_and_kill_app()
 
 


### PR DESCRIPTION
- Catch the webdriver error and treat it as element not found. There can be an error even if the element is visible due to reload or refresh.
- split gui test suites