### PR TITLE
chore(gui-test): additional ruff linter rules

### DIFF
--- a/test/gui/helpers/AppHelper.py
+++ b/test/gui/helpers/AppHelper.py
@@ -54,9 +54,7 @@ def find_element(self, by, selector, timeout=None):
             visible_elements = [el for el in elements if el.is_displayed()]
             if len(visible_elements) == 1:
                 return visible_elements.pop()
-            raise WebDriverException(
-                f'Found {elements_count} elements using "{by}={selector}"'
-            )
+            raise WebDriverException(f'Found {elements_count} elements using "{by}={selector}"')
         if elements_count == 0:
             raise NoSuchElementException(f'No element found for "{by}={selector}"')
         return elements[0]
@@ -141,11 +139,7 @@ def wait_until_app_terminated():
 
 
 def get_window_location():
-    window = (
-        app()
-        .find_element(By.XPATH, "//*[contains(@name,'OpenCloud Desktop')]")
-        .location
-    )
+    window = app().find_element(By.XPATH, "//*[contains(@name,'OpenCloud Desktop')]").location
     return window['x'], window['y']
 
 

--- a/test/gui/helpers/ConfigHelper.py
+++ b/test/gui/helpers/ConfigHelper.py
@@ -36,9 +36,7 @@ def get_config_home_linux():
 
 
 def get_config_home_win():
-    return os.path.join(
-        get_win_user_home(), 'AppData', 'Local', 'Temp', 'opencloudtest', '.config'
-    )
+    return os.path.join(get_win_user_home(), 'AppData', 'Local', 'Temp', 'opencloudtest', '.config')
 
 
 def get_config_home():
@@ -73,9 +71,7 @@ CONFIG_ENV_MAP = {
 
 # immutable configs
 DEFAULT_PATH_CONFIG = {
-    'custom_lib': os.path.abspath(
-        os.path.join(os.path.dirname(__file__), 'custom_lib')
-    ),
+    'custom_lib': os.path.abspath(os.path.join(os.path.dirname(__file__), 'custom_lib')),
     'home_dir': get_default_home_dir(),
     'clientConfigFile': os.path.join(get_config_home(), "OpenCloud", APP_CONFIG_FILE),
     # allow to record first 5 videos
@@ -103,9 +99,15 @@ CONFIG = {
     ###############################
     # dynamic configs             #
     ###############################
-    # currentAppLogFile: file path to store app logs for the current scenario run, initialized in init_config()
-    # appLogFile: file path to store cumulative app logs for the entire test run, initialized in init_config()
-    # currentUserSyncPath: path to store the current user's sync data, initialized in init_config()
+    # currentAppLogFile:
+    #       file path to store app logs for the current scenario run,
+    #       initialized in init_config()
+    # appLogFile:
+    #       file path to store cumulative app logs for the entire test run,
+    #       initialized in init_config()
+    # currentUserSyncPath:
+    #       path to store the current user's sync data,
+    #       initialized in init_config()
 }
 
 # space membership permission roles mapping
@@ -172,13 +174,9 @@ def init_config():
 
     ### initialize dynamic config values
     # file to store app logs for the current scenario run
-    CONFIG['currentAppLogFile'] = os.path.join(
-        CONFIG["guiTestReportDir"], CURRENT_APP_LOG_FILE
-    )
+    CONFIG['currentAppLogFile'] = os.path.join(CONFIG["guiTestReportDir"], CURRENT_APP_LOG_FILE)
     # file to store cumulative app logs for the entire test run
-    CONFIG['appLogFile'] = os.path.join(
-        CONFIG["guiTestReportDir"], CUMULATIVE_APP_LOG_FILE
-    )
+    CONFIG['appLogFile'] = os.path.join(CONFIG["guiTestReportDir"], CUMULATIVE_APP_LOG_FILE)
     # file to store cumulative app logs for the entire test run
     CONFIG['crash_report_file'] = os.path.join(CONFIG["guiTestReportDir"], 'crash.log')
     # create report dir if it not exist

--- a/test/gui/helpers/FilesHelper.py
+++ b/test/gui/helpers/FilesHelper.py
@@ -15,9 +15,12 @@ def build_conflicted_regex(filename):
         # TODO: improve this for complex filenames
         namepart = filename.split(".")[0]
         extpart = filename.split(".")[1]
-        # pylint: disable=anomalous-backslash-in-string
-        return rf"{namepart} \(conflicted copy \d{{4}}-\d{{2}}-\d{{2}} \d{{6}}\)\.{extpart}"
-    # pylint: disable=anomalous-backslash-in-string
+        return (
+            rf"{namepart} \(conflicted copy "
+            r"\d{4}-\d{2}-\d{2} "
+            r"\d{6}\)"
+            rf"\.{extpart}"
+        )
     return rf"{filename} \(conflicted copy \d{{4}}-\d{{2}}-\d{{2}} \d{{6}}\)"
 
 
@@ -57,8 +60,7 @@ def can_write(resource):
 
 def read_file_content(file):
     with open(file, encoding="utf-8") as f:
-        content = f.read()
-    return content
+        return f.read()
 
 
 def is_empty_sync_folder(folder):
@@ -143,8 +145,7 @@ def get_pdf_content(pdf_file):
 
 def get_docs_content(docs_file):
     doc = Document(docs_file)
-    content = "\n".join(p.text for p in doc.paragraphs)
-    return content
+    return "\n".join(p.text for p in doc.paragraphs)
 
 
 def get_presentation_content(ppt_file):

--- a/test/gui/helpers/ReportHelper.py
+++ b/test/gui/helpers/ReportHelper.py
@@ -7,8 +7,7 @@ from helpers.ConfigHelper import get_config
 
 def normalize_scenario_title(title):
     scenario_title = title.lower().strip()
-    scenario_title = re.sub(r'\W', '_', scenario_title)
-    return scenario_title
+    return re.sub(r'\W', '_', scenario_title)
 
 
 def get_screenrecords_path():
@@ -49,9 +48,7 @@ def take_screenshot(filename):
 def save_app_log(scenario):
     with open(get_config('appLogFile'), 'a') as log_file:
         logs = ["=" * 80]
-        logs.append(
-            f"Scenario: {scenario.name}\nLocation: {scenario.filename}:{scenario.line}"
-        )
+        logs.append(f"Scenario: {scenario.name}\nLocation: {scenario.filename}:{scenario.line}")
         logs.append("-" * 80)
         logs.append("")  # extra line break
         log_file.write("\n".join(logs))
@@ -68,9 +65,7 @@ def cleanup_current_app_log():
 def save_crash_log(scenario):
     with open(get_config('crash_report_file'), 'a') as log_file:
         logs = ["=" * 80]
-        logs.append(
-            f"Scenario: {scenario.name}\nLocation: {scenario.filename}:{scenario.line}"
-        )
+        logs.append(f"Scenario: {scenario.name}\nLocation: {scenario.filename}:{scenario.line}")
         logs.append("-" * 80)
         logs.append("")  # extra line break
         log_file.write("\n".join(logs))

--- a/test/gui/helpers/ScreenRecorder.py
+++ b/test/gui/helpers/ScreenRecorder.py
@@ -51,9 +51,7 @@ def start_recording(filename):
     _video_path = get_screenrecord_file_path(filename)
     _stop_event.clear()
 
-    _recording_thread = threading.Thread(
-        target=_record_loop, args=(_video_path,), daemon=True
-    )
+    _recording_thread = threading.Thread(target=_record_loop, args=(_video_path,), daemon=True)
     _recording_thread.start()
 
 

--- a/test/gui/helpers/SetupClientHelper.py
+++ b/test/gui/helpers/SetupClientHelper.py
@@ -16,12 +16,8 @@ def substitute_inline_codes(value):
     value = value.replace('%local_server%', get_config('localBackendUrl'))
     value = value.replace('%client_root_sync_path%', get_config('clientRootSyncPath'))
     value = value.replace('%current_user_sync_path%', get_config('currentUserSyncPath'))
-    value = value.replace(
-        '%local_server_hostname%', urlparse(get_config('localBackendUrl')).netloc
-    )
-    value = value.replace('%home%', get_config('home_dir'))
-
-    return value
+    value = value.replace('%local_server_hostname%', urlparse(get_config('localBackendUrl')).netloc)
+    return value.replace('%home%', get_config('home_dir'))
 
 
 def get_client_details(table):

--- a/test/gui/helpers/SpaceHelper.py
+++ b/test/gui/helpers/SpaceHelper.py
@@ -111,8 +111,9 @@ def create_space_file(space_name, file_name, content):
     response = request.put(url, content)
     if response.status_code not in (201, 204):
         raise AssertionError(
-            f"Creating file '{file_name}' in space '{space_name}' failed with {response.status_code}\n"
-            + response.text
+            f"Creating file '{file_name}' in space "
+            f"'{space_name}' failed with "
+            f"{response.status_code}\n"
         )
 
 

--- a/test/gui/helpers/StacktraceHelper.py
+++ b/test/gui/helpers/StacktraceHelper.py
@@ -41,7 +41,8 @@ def parse_stacktrace(coredump_file):
     message = []
     if coredump_file:
         coredump_filename = os.path.basename(coredump_file)
-        # example coredump file: core-1648445754-1001-11-!drone!src!build-GUI-tests!bin!opencloud
+        # example coredump file:
+        #       core-1648445754-1001-11-!drone!src!build-GUI-tests!bin!opencloud
         patterns = coredump_filename.split('-')
         app_binary = 'opencloud'
         if len(patterns) == 1:
@@ -52,7 +53,7 @@ def parse_stacktrace(coredump_file):
             app_binary = '-'.join(patterns[4:]).replace('!', '/')
 
         timestamp = datetime.fromtimestamp(
-            float(patterns[1] if patterns[1] != 'N/A' else time.time())
+            float(patterns[1] if patterns[1] != 'N/A' else time.time()), tz=datetime.UTC
         )
         message.append('-------------------------------------------')
         message.append(f'Executable: {app_binary}')

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -29,7 +29,11 @@ else:
         content = content.replace('socketConnect = SocketConnect()', '')
         content = content.replace(
             'from gi.repository import GObject, Nautilus',
-            'import gi\n\ngi.require_version(\'Nautilus\', \'4.0\')\nfrom gi.repository import GObject, Nautilus',
+            (
+                "import gi\n\n"
+                "gi.require_version('Nautilus', '4.0')\n"
+                "from gi.repository import GObject, Nautilus"
+            ),
         )
 
         with open(syncstate_lib_file, 'w') as f:
@@ -65,7 +69,8 @@ SYNC_STATUS = {
 
 SYNC_PATTERNS = {
     # default sync patterns for the initial sync (after adding account)
-    # the pattern can be of TWO types depending on the available resources (files/folders)
+    # the pattern can be of TWO types depending on the
+    # available resources (files/folders)
     'initial': [
         # when adding account via New Account wizard
         [
@@ -157,9 +162,7 @@ def clear_socket_messages(resource=''):
     global socket_messages
     if resource:
         resource_messages = set(filter_messages_for_item(socket_messages, resource))
-        socket_messages = [
-            msg for msg in socket_messages if msg not in resource_messages
-        ]
+        socket_messages = [msg for msg in socket_messages if msg not in resource_messages]
     else:
         socket_messages.clear()
 
@@ -290,11 +293,7 @@ def wait_for_resource_to_sync(
     if synced:
         if check_queued:
             loaded = wait_for(
-                lambda: (
-                    not SyncConnection.is_sync_in_progress(
-                        get_config('syncConnectionName')
-                    )
-                ),
+                lambda: not SyncConnection.is_sync_in_progress(get_config('syncConnectionName')),
                 get_config('sync_timeout'),
             )
             sync_info.append(f'Sync complete (UI): {loaded}')
@@ -304,7 +303,7 @@ def wait_for_resource_to_sync(
                     + '\n'.join(sync_info)
                 )
         return
-    elif not force_sync:
+    if not force_sync:
         # if the sync pattern doesn't match then check the last sync status
         # and pass the step if the last sync status is STATUS:OK
         status = get_current_sync_status(resource, resource_type)
@@ -343,9 +342,7 @@ def has_sync_pattern(patterns, resource=None):
     for pattern in patterns:
         pattern_len = len(pattern)
         for idx, _ in enumerate(messages):
-            actual_pattern = generate_sync_pattern_from_messages(
-                messages[idx : idx + pattern_len]
-            )
+            actual_pattern = generate_sync_pattern_from_messages(messages[idx : idx + pattern_len])
             if len(actual_pattern) < pattern_len:
                 break
             if pattern_len == len(actual_pattern) and pattern == actual_pattern:
@@ -392,9 +389,7 @@ def wait_for_resource_to_have_sync_status(
             expected = 'be sync ignored'
         else:
             expected = 'be synced'
-        raise ValueError(
-            f'Expected {resource_type} "{resource}" to {expected}, but not.'
-        )
+        raise ValueError(f'Expected {resource_type} "{resource}" to {expected}, but not.')
 
 
 def wait_for_resource_to_have_sync_error(resource, resource_type):

--- a/test/gui/helpers/TableParser.py
+++ b/test/gui/helpers/TableParser.py
@@ -65,7 +65,8 @@ def table_rows_hash(table: Table):
     """
     if len(table.headings) != 2:
         raise ValueError(
-            "table_rows_hash() can only be called on a data table where all rows have exactly two columns."
+            "table_rows_hash() can only be called on a data table "
+            "where all rows have exactly two columns."
         )
 
     data_table = {
@@ -81,7 +82,8 @@ def table_hashes(table: Table):
     Args:
         table (Table): Behave Table object.
     Returns:
-        list: List of dictionaries, where each dictionary represents a row with keys from the header and values from the corresponding cells.
+        list: List of dictionaries, where each dictionary represents a row
+        with keys from the header and values from the corresponding cells.
 
     Example:
         | key1    | key2    | key3   |

--- a/test/gui/helpers/VFSFileHelper.py
+++ b/test/gui/helpers/VFSFileHelper.py
@@ -94,8 +94,7 @@ def get_compressed_file_size(path):
 def resource_archived(resource_path):
     if is_windows():
         return bool(
-            get_file_attributes(resource_path)
-            & FileAttributeConstants.FILE_ATTRIBUTE_ARCHIVE
+            get_file_attributes(resource_path) & FileAttributeConstants.FILE_ATTRIBUTE_ARCHIVE
         )
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
 
@@ -103,8 +102,7 @@ def resource_archived(resource_path):
 def resource_pinned(resource_path):
     if is_windows():
         return bool(
-            get_file_attributes(resource_path)
-            & FileAttributeConstants.FILE_ATTRIBUTE_PINNED
+            get_file_attributes(resource_path) & FileAttributeConstants.FILE_ATTRIBUTE_PINNED
         )
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
 
@@ -112,8 +110,7 @@ def resource_pinned(resource_path):
 def resource_unpinned(resource_path):
     if is_windows():
         return bool(
-            get_file_attributes(resource_path)
-            & FileAttributeConstants.FILE_ATTRIBUTE_UNPINNED
+            get_file_attributes(resource_path) & FileAttributeConstants.FILE_ATTRIBUTE_UNPINNED
         )
     raise OSError(error_message % inspect.currentframe().f_back.f_code.co_name)
 

--- a/test/gui/helpers/WinPipeHelper.py
+++ b/test/gui/helpers/WinPipeHelper.py
@@ -25,8 +25,7 @@ CLIENT_MESSAGES = [
 
 def get_pipe_path():
     pipename = r'\\.\\pipe\\'
-    pipename = os.path.join(pipename, 'openCloud-' + os.getenv('USERNAME'))
-    return pipename
+    return os.path.join(pipename, 'openCloud-' + os.getenv('USERNAME'))
 
 
 class WinPipeConnect:
@@ -64,17 +63,13 @@ class WinPipeConnect:
 
     def sendCommand(self, cmd):  # noqa: N802
         if self.connected:
-            w_res, _ = win32file.WriteFile(
-                self._pipe, cmd.encode('utf-8'), self._overlapped
-            )
+            w_res, _ = win32file.WriteFile(self._pipe, cmd.encode('utf-8'), self._overlapped)
             if w_res == winerror.ERROR_IO_PENDING:
                 res = win32event.WaitForSingleObject(self._overlapped.hEvent, TIMEOUT)
                 if res != win32event.WAIT_OBJECT_0:
                     print('Sending timed out!')
                     return False
-                if not win32file.GetOverlappedResult(
-                    self._pipe, self._overlapped, False
-                ):
+                if not win32file.GetOverlappedResult(self._pipe, self._overlapped, False):
                     print('GetOverlappedResult failed')
                     return False
         else:
@@ -94,9 +89,7 @@ class WinPipeConnect:
 
             peek_bytes = win32pipe.PeekNamedPipe(self._pipe, DEFAULT_BUFLEN)[1]
             if isinstance(peek_bytes, int) and peek_bytes > 0:
-                _, message_mem = win32file.ReadFile(
-                    self._pipe, DEFAULT_BUFLEN, self._overlapped
-                )
+                _, message_mem = win32file.ReadFile(self._pipe, DEFAULT_BUFLEN, self._overlapped)
                 if message_mem:
                     m_bytes = bytes(message_mem)
                     if b'\n' in m_bytes:
@@ -111,15 +104,11 @@ class WinPipeConnect:
                                 pass
 
             else:
-                res = win32event.WaitForSingleObject(
-                    self._overlapped.hEvent, int(timeout * 1000)
-                )
+                res = win32event.WaitForSingleObject(self._overlapped.hEvent, int(timeout * 1000))
                 if res != win32event.WAIT_OBJECT_0:
                     print('Reading timed out!')
                     return False
-                if not win32file.GetOverlappedResult(
-                    self._pipe, self._overlapped, False
-                ):
+                if not win32file.GetOverlappedResult(self._pipe, self._overlapped, False):
                     return False
         return True
 

--- a/test/gui/helpers/api/http_helper.py
+++ b/test/gui/helpers/api/http_helper.py
@@ -25,9 +25,7 @@ def send_request(url, method, body=None, headers=None, user=None, password=None)
 
 
 def get(url, headers=None, user=None, password=None):
-    return send_request(
-        url=url, method="GET", headers=headers, user=user, password=password
-    )
+    return send_request(url=url, method="GET", headers=headers, user=user, password=password)
 
 
 def post(url, body=None, headers=None, user=None):

--- a/test/gui/helpers/api/provisioning.py
+++ b/test/gui/helpers/api/provisioning.py
@@ -66,5 +66,4 @@ def get_capabilities():
     response_str = response.text
     response_doc = QJsonDocument.fromJson(response_str.encode("utf-8"))
     response_obj = response_doc.object()
-    capabilities = response_obj.get('ocs').get('data').get('capabilities')
-    return capabilities
+    return response_obj.get('ocs').get('data').get('capabilities')

--- a/test/gui/helpers/api/webdav_helper.py
+++ b/test/gui/helpers/api/webdav_helper.py
@@ -22,8 +22,7 @@ def get_resource_path(user, resource):
     resource = resource.strip('/').replace('\\', '/')
     encoded_resource_path = [quote(path, safe='') for path in resource.split('/')]
     encoded_resource_path = '/'.join(encoded_resource_path)
-    url = url_join(get_webdav_url(), user, encoded_resource_path)
-    return url
+    return url_join(get_webdav_url(), user, encoded_resource_path)
 
 
 def resource_exists(user, resource):
@@ -48,9 +47,7 @@ def get_folder_items(user, resource):
     xml_response = request.propfind(path, user=user)
 
     if xml_response.status_code != 207:
-        raise AssertionError(
-            f'Failed to get resource properties: {xml_response.status_code}'
-        )
+        raise AssertionError(f'Failed to get resource properties: {xml_response.status_code}')
 
     return ET.fromstring(xml_response.content)
 
@@ -135,15 +132,11 @@ def send_resource_share_invitation(user, resource, sharee, permission_role):
     recipient_user_id = get_user_id(sharee)
     role_id = get_permission_role_id(permission_role)
 
-    url = url_join(
-        get_beta_graph_url(), "drives", space_id, "items", resource_id, "invite"
-    )
+    url = url_join(get_beta_graph_url(), "drives", space_id, "items", resource_id, "invite")
 
     body = {
         "roles": [role_id],
-        "recipients": [
-            {"objectId": recipient_user_id, "@libre.graph.recipient.type": "user"}
-        ],
+        "recipients": [{"objectId": recipient_user_id, "@libre.graph.recipient.type": "user"}],
     }
 
     response = request.post(url, body=json.dumps(body), user=user)

--- a/test/gui/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/pageObjects/AccountConnectionWizard.py
@@ -173,9 +173,7 @@ class AccountConnectionWizard:
             )
         elif account_details["user"]:
             AccountConnectionWizard.select_advanced_config()
-            sync_path = AccountConnectionWizard.select_sync_folder(
-                account_details["user"]
-            )
+            sync_path = AccountConnectionWizard.select_sync_folder(account_details["user"])
         if sync_path:
             # listen for sync status
             listen_sync_status_for_item(sync_path)
@@ -196,7 +194,7 @@ class AccountConnectionWizard:
 
     @staticmethod
     def is_credential_window_visible():
-        visible = (
+        return (
             app()
             .find_element(
                 AccountConnectionWizard.LOGIN_DIALOG.by,
@@ -204,7 +202,6 @@ class AccountConnectionWizard:
             )
             .is_displayed()
         )
-        return visible
 
     @staticmethod
     def select_advanced_config():

--- a/test/gui/pageObjects/AccountSetting.py
+++ b/test/gui/pageObjects/AccountSetting.py
@@ -10,14 +10,10 @@ from helpers.ConfigHelper import get_config
 
 
 class AccountSetting:
-    ACCOUNT_CONNECTION_CONTAINER = SimpleNamespace(
-        by=By.NAME, selector="Sync connections"
-    )
+    ACCOUNT_CONNECTION_CONTAINER = SimpleNamespace(by=By.NAME, selector="Sync connections")
     MANAGE_ACCOUNT_BUTTON = SimpleNamespace(by=By.NAME, selector="Manage Account")
     ACCOUNT_MENU = SimpleNamespace(by=By.NAME, selector="{menu_item}")
-    CONFIRM_REMOVE_CONNECTION_BUTTON = SimpleNamespace(
-        by=By.NAME, selector="Remove connection"
-    )
+    CONFIRM_REMOVE_CONNECTION_BUTTON = SimpleNamespace(by=By.NAME, selector="Remove connection")
     ACCOUNT_CONNECTION_LABEL = SimpleNamespace(
         by=By.XPATH,
         selector="//list[@name='Folder Sync']//label",
@@ -86,9 +82,7 @@ class AccountSetting:
 
         if not result:
             raise TimeoutError(
-                "Timeout waiting for the account to be connected for "
-                + str(timeout)
-                + " seconds"
+                "Timeout waiting for the account to be connected for " + str(timeout) + " seconds"
             )
         return result
 
@@ -110,7 +104,5 @@ class AccountSetting:
 
         if not result:
             raise TimeoutError(
-                "Timeout waiting for account to be removed for "
-                + str(timeout)
-                + " seconds"
+                "Timeout waiting for account to be removed for " + str(timeout) + " seconds"
             )

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -41,9 +41,7 @@ class Activity:
                 app()
                 .find_element(
                     Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.by,
-                    Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.selector.format(
-                        filename=filename
-                    ),
+                    Activity.NOT_SYNCED_ACTIVITY_CONFLICT_FILE.selector.format(filename=filename),
                 )
                 .is_displayed()
             ),
@@ -54,36 +52,31 @@ class Activity:
 
     @staticmethod
     def is_resource_blacklisted(filename):
-        result = wait_for(
+        return wait_for(
             lambda: Activity.has_sync_status(filename, "Blacklisted"),
             get_config("sync_timeout"),
         )
-        return result
 
     @staticmethod
     def is_resource_ignored(filename):
-        result = wait_for(
+        return wait_for(
             lambda: Activity.has_sync_status(filename, "File Ignored"),
             get_config("sync_timeout"),
         )
-        return result
 
     @staticmethod
     def is_resource_excluded(filename):
-        result = wait_for(
+        return wait_for(
             lambda: Activity.has_sync_status(filename, "Excluded"),
             get_config("sync_timeout"),
         )
-        return result
 
     @staticmethod
     def has_sync_status(filename, status):
         try:
             row = app().find_element(By.NAME, filename)
             row_y = row.rect['y']
-            status_cells = app().find_elements(
-                Activity.SYNCED_ACTIVITY_STATUS.by, status
-            )
+            status_cells = app().find_elements(Activity.SYNCED_ACTIVITY_STATUS.by, status)
             for status_el in status_cells:
                 if status_el.rect['y'] == row_y:
                     return True

--- a/test/gui/pageObjects/Settings.py
+++ b/test/gui/pageObjects/Settings.py
@@ -64,9 +64,7 @@ class Settings:
 
     @staticmethod
     def open_about_dialog():
-        app().find_element(
-            Settings.ABOUT_BUTTON.by, Settings.ABOUT_BUTTON.selector
-        ).click()
+        app().find_element(Settings.ABOUT_BUTTON.by, Settings.ABOUT_BUTTON.selector).click()
 
     @staticmethod
     def has_about_dialog():

--- a/test/gui/pageObjects/SyncConnection.py
+++ b/test/gui/pageObjects/SyncConnection.py
@@ -8,17 +8,13 @@ from helpers.Utils import wait_for
 
 
 class SyncConnection:
-    ACCOUNT_CONNECTION_CONTAINER = SimpleNamespace(
-        by=By.NAME, selector="Sync connections"
-    )
+    ACCOUNT_CONNECTION_CONTAINER = SimpleNamespace(by=By.NAME, selector="Sync connections")
     FOLDER_SYNC_CONNECTION_MENU_BUTTON = SimpleNamespace(
         by=By.NAME,
         selector="{sync_folder},{status},Local folder: {sync_path}{sync_folder}",
     )
     MENU_ITEM = SimpleNamespace(by=By.NAME, selector=None)
-    CONFIRM_FOLDER_SYNC_CONNECTION_REMOVE = SimpleNamespace(
-        by=By.NAME, selector="Remove Space"
-    )
+    CONFIRM_FOLDER_SYNC_CONNECTION_REMOVE = SimpleNamespace(by=By.NAME, selector="Remove Space")
     PERMISSION_ERROR_LABEL = SimpleNamespace(
         by=By.XPATH, selector="//label[contains(@name, 'permission')]"
     )

--- a/test/gui/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/pageObjects/SyncConnectionWizard.py
@@ -22,9 +22,7 @@ class SyncConnectionWizard:
         by=By.XPATH, selector="//dialog[@name='Add Space']//*[@name='Add Space']"
     )
     SELECTIVE_SYNC_TREE_HEADER = SimpleNamespace(by=By.NAME, selector='{header}')
-    CANCEL_FOLDER_SYNC_CONNECTION_WIZARD = SimpleNamespace(
-        by=By.NAME, selector="Cancel"
-    )
+    CANCEL_FOLDER_SYNC_CONNECTION_WIZARD = SimpleNamespace(by=By.NAME, selector="Cancel")
     SPACES_LIST = SimpleNamespace(by=By.NAME, selector="Spaces list")
     SPACE_NAME_SELECTOR = SimpleNamespace(by=By.NAME, selector="{space_name},")
     ADD_SPACE_BUTTON = SimpleNamespace(by=By.NAME, selector='Add Space')
@@ -75,9 +73,7 @@ class SyncConnectionWizard:
     def sort_by(header_text):
         element = app().find_element(
             SyncConnectionWizard.SELECTIVE_SYNC_TREE_HEADER.by,
-            SyncConnectionWizard.SELECTIVE_SYNC_TREE_HEADER.selector.format(
-                header=header_text
-            ),
+            SyncConnectionWizard.SELECTIVE_SYNC_TREE_HEADER.selector.format(header=header_text),
         )
         # ISSUE: https://github.com/opencloud-eu/desktop/pull/879
         # Cannot select table header element by click event
@@ -126,9 +122,7 @@ class SyncConnectionWizard:
         )
         space_item = spaces_list.find_element(
             SyncConnectionWizard.SPACE_NAME_SELECTOR.by,
-            SyncConnectionWizard.SPACE_NAME_SELECTOR.selector.format(
-                space_name=space_name
-            ),
+            SyncConnectionWizard.SPACE_NAME_SELECTOR.selector.format(space_name=space_name),
         )
         # ISSUE: https://github.com/opencloud-eu/desktop/pull/879
         # Cannot select space by click event
@@ -168,6 +162,7 @@ class SyncConnectionWizard:
         for folder in possible_els:
             if folder.rect["x"] > parent_row:
                 return folder
+        return None
 
     @staticmethod
     def toggle_folder_selection(folders, select=True):
@@ -182,9 +177,7 @@ class SyncConnectionWizard:
             target_element = None
             for idx, parent in enumerate(parents):
                 p_elements = app().find_elements(By.NAME, parent)
-                next_item = (
-                    parents[idx + 1] if idx + 1 < len(parents) else target_folder
-                )
+                next_item = parents[idx + 1] if idx + 1 < len(parents) else target_folder
                 # select nested folders based on the position of the parent folder
                 for p_element in p_elements:
                     if p_element.rect["x"] >= parent_position and (

--- a/test/gui/pageObjects/Toolbar.py
+++ b/test/gui/pageObjects/Toolbar.py
@@ -11,13 +11,9 @@ from helpers.Utils import wait_for
 
 class Toolbar:
     TOOLBAR_ROW = SimpleNamespace(by=None, selector=None)
-    NAVIGATION_BAR = SimpleNamespace(
-        by=By.XPATH, selector="//*[@name='Navigation bar']/.."
-    )
+    NAVIGATION_BAR = SimpleNamespace(by=By.XPATH, selector="//*[@name='Navigation bar']/..")
     ACCOUNT_TAB = SimpleNamespace(by=By.CLASS_NAME, selector="[page tab | {text}]")
-    ADD_ACCOUNT_BUTTON = SimpleNamespace(
-        by=By.CLASS_NAME, selector="[push button | Add Account]"
-    )
+    ADD_ACCOUNT_BUTTON = SimpleNamespace(by=By.CLASS_NAME, selector="[push button | Add Account]")
     ACTIVITY_TAB = SimpleNamespace(by=By.CLASS_NAME, selector="[page tab | Activity]")
     SETTINGS_TAB = SimpleNamespace(by=By.CLASS_NAME, selector="[page tab | Settings]")
     QUIT_BUTTON = SimpleNamespace(by=By.CLASS_NAME, selector="[push button | Quit]")
@@ -28,9 +24,7 @@ class Toolbar:
 
     @staticmethod
     def wait_toolbar_enabled():
-        toolbar = app().find_element(
-            Toolbar.NAVIGATION_BAR.by, Toolbar.NAVIGATION_BAR.selector
-        )
+        toolbar = app().find_element(Toolbar.NAVIGATION_BAR.by, Toolbar.NAVIGATION_BAR.selector)
         timeout = get_config('max_timeout')
         enabled = wait_for(
             toolbar.is_enabled,

--- a/test/gui/pyproject.toml
+++ b/test/gui/pyproject.toml
@@ -30,6 +30,9 @@ lint = [
     "ruff>=0.15.20",
 ]
 
+[tool.ruff]
+line-length = 100
+
 [tool.ruff.format]
 quote-style = "preserve"
 
@@ -43,10 +46,12 @@ select = [
     "RUF",
     "PIE",
     "PLW2901",
+    "DTZ",
+    "RET",
 ]
 
+# See the available rules: https://docs.astral.sh/ruff/rules/
 ignore = [
-    "E501",     # Line too long
     "F403",     # Wildcard import (`from x import *`)
     "E722",     # Bare `except`
     "SIM105",   # Use `contextlib.suppress`
@@ -58,5 +63,5 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"steps/*.py" = ["F811"]
+"steps/*.py" = ["F811", "E501"]
 "steps/vfs_context.py" = ["F821"]

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -109,10 +109,7 @@ def add_copy_suffix(resource_path, resource_type):
 
 
 def copy_resource(resource_type, source, destination, from_files_for_upload=False):
-    if from_files_for_upload:
-        source = get_file_for_upload(source)
-    else:
-        source = get_resource_path(source)
+    source = get_file_for_upload(source) if from_files_for_upload else get_resource_path(source)
     destination = get_resource_path(destination)
     if source == destination and destination != '/':
         destination = add_copy_suffix(source, resource_type)
@@ -161,9 +158,7 @@ def step(context, username, foldername):
     create_folder(foldername, username)
 
 
-@When(
-    'user "{user}" creates a file "{filename}" with size "{filesize}" inside the sync folder'
-)
+@When('user "{user}" creates a file "{filename}" with size "{filesize}" inside the sync folder')
 def step(context, user, filename, filesize):
     create_file_with_size(filename, filesize)
 
@@ -173,9 +168,7 @@ def step(context, resource_type, resource_name, destination_dir):
     copy_resource(resource_type, resource_name, destination_dir, False)
 
 
-@When(
-    'the user copies {resource_type:ResourceType} "{resource_name}" into the same directory'
-)
+@When('the user copies {resource_type:ResourceType} "{resource_name}" into the same directory')
 def step(context, resource_type, resource_name):
     copy_resource(resource_type, resource_name, resource_name, False)
 
@@ -186,9 +179,7 @@ def step(context, source, destination):
     rename_file_folder(source, destination)
 
 
-@Then(
-    'the file "{file_path}" should exist on the file system with the following content'
-)
+@Then('the file "{file_path}" should exist on the file system with the following content')
 def step(context, file_path):
     expected = context.text
     file_path = get_resource_path(file_path)
@@ -221,9 +212,7 @@ def step(context, resource_type, resource):
         resource_exists.should.be.true
 
 
-@Then(
-    'the {resource_type:ResourceType} "{resource}" should not exist on the file system'
-)
+@Then('the {resource_type:ResourceType} "{resource}" should not exist on the file system')
 def step(context, resource_type, resource):
     resource_path = get_resource_path(resource)
     with ensure(
@@ -240,15 +229,11 @@ def step(context, filename):
     write_file_to_sync_path(get_resource_path(filename), file_content)
 
 
-@Then(
-    'a conflict file for "{filename}" should exist on the file system with the following content'
-)
+@Then('a conflict file for "{filename}" should exist on the file system with the following content')
 def step(context, filename):
     expected = context.text
 
-    onlyfiles = [
-        f for f in os.listdir(get_resource_path()) if isfile(get_resource_path(f))
-    ]
+    onlyfiles = [f for f in os.listdir(get_resource_path()) if isfile(get_resource_path(f))]
     found = False
     pattern = re.compile(build_conflicted_regex(filename))
     for file in onlyfiles:
@@ -308,9 +293,7 @@ def step(context, file_number, file_size, folder_name):
             file_name = f'file{i}.txt'
             create_file_with_size(join(current_sync_path, file_name), file_size, True)
     else:
-        raise FileNotFoundError(
-            f"Folder '{folder_name}' does not exist in the temp folder"
-        )
+        raise FileNotFoundError(f"Folder '{folder_name}' does not exist in the temp folder")
 
 
 @When(
@@ -358,9 +341,7 @@ def step(context, user, file_name):
         can_read(file_path).should.be.true
 
 
-@Then(
-    'as "{user}" the file "{file_name}" should have content "{content}" on the file system'
-)
+@Then('as "{user}" the file "{file_name}" should have content "{content}" on the file system')
 def step(context, user, file_name, content):
     file_path = get_resource_path(file_name, user)
     file_content = read_file_content(file_path)
@@ -373,9 +354,7 @@ def step(context, user, file_name, content):
         content.should.equal(file_content)
 
 
-@Then(
-    'user "{user}" should not be able to edit the file "{file_name}" on the file system'
-)
+@Then('user "{user}" should not be able to edit the file "{file_name}" on the file system')
 def step(context, user, file_name):
     file_path = get_resource_path(file_name, user)
     with ensure('File should not be writable, but it is'):
@@ -447,8 +426,6 @@ def step(context):
         delete_resource(filename, 'file')
 
 
-@Given(
-    'the user has created a file "{filename}" with size "{filesize}" in the sync folder'
-)
+@Given('the user has created a file "{filename}" with size "{filesize}" in the sync folder')
 def step(context, filename, filesize):
     create_file_with_size(filename, filesize)

--- a/test/gui/steps/server_context.py
+++ b/test/gui/steps/server_context.py
@@ -27,9 +27,7 @@ def step(context, user_name, resource_type, resource_name):
         resource_exists.should.be.false
 
 
-@Then(
-    'as "{user_name}" {resource_type:ResourceType} "{resource_name}" should exist in the server'
-)
+@Then('as "{user_name}" {resource_type:ResourceType} "{resource_name}" should exist in the server')
 def step(context, user_name, resource_type, resource_name):
     resource_exists = webdav.resource_exists(user_name, resource_name)
     with ensure(
@@ -40,9 +38,7 @@ def step(context, user_name, resource_type, resource_name):
         resource_exists.should.be.true
 
 
-@Then(
-    'as "{user_name}" the file "{file_name}" should have the content "{content}" in the server'
-)
+@Then('as "{user_name}" the file "{file_name}" should have the content "{content}" in the server')
 def step(context, user_name, file_name, content):
     text_content = webdav.get_file_content(user_name, file_name)
     with ensure(
@@ -75,9 +71,7 @@ def step(context, user, file_content, file_name):
     webdav.create_file(user, file_name, file_content)
 
 
-@When(
-    'user "{user}" uploads file with content "{file_content}" to "{file_name}" in the server'
-)
+@When('user "{user}" uploads file with content "{file_content}" to "{file_name}" in the server')
 def step(context, user, file_content, file_name):
     webdav.create_file(user, file_name, file_content)
 

--- a/test/gui/steps/spaces_context.py
+++ b/test/gui/steps/spaces_context.py
@@ -34,9 +34,7 @@ def step(context, file_name, content, space_name):
     create_space_file(space_name, file_name, content)
 
 
-@Given(
-    'the administrator has added user "{user}" to space "{space_name}" with role "{role}"'
-)
+@Given('the administrator has added user "{user}" to space "{space_name}" with role "{role}"')
 def step(context, user, space_name, role):
     add_user_to_space(user, space_name, role)
 
@@ -69,12 +67,8 @@ def step(context, user, file_name, space_name, content):
         content.should.equal(downloaded_content)
 
 
-@Then(
-    'as "{user}" the space "{space_name}" should have file "{resource_name}" in the server'
-)
-@Then(
-    'as "{user}" the space "{space_name}" should have folder "{resource_name}" in the server'
-)
+@Then('as "{user}" the space "{space_name}" should have file "{resource_name}" in the server')
+@Then('as "{user}" the space "{space_name}" should have folder "{resource_name}" in the server')
 def step(context, user, space_name, resource_name):
     exists = resource_exists(space_name, resource_name, user)
     with ensure('Resource "{0}" should exist but it does not', resource_name):

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -75,9 +75,7 @@ def step(context, resource_type, resource):
     wait_for_resource_to_have_sync_error(resource, resource_type)
 
 
-@When(
-    r'user "([^"]*)" waits for (file|folder) "([^"]*)" to have sync error', regexp=True
-)
+@When(r'user "([^"]*)" waits for (file|folder) "([^"]*)" to have sync error', regexp=True)
 def step(context, username, resource_type, resource):
     resource = get_resource_path(resource, username)
     wait_for_resource_to_have_sync_error(resource, resource_type)
@@ -136,9 +134,7 @@ def step(context):
     for row in context.table:
         folders.append(row[0])
     SyncConnectionWizard.deselect_all_remote_folders()
-    SyncConnectionWizard.select_folders_to_sync(
-        folders, new_sync_connection_wizard=True
-    )
+    SyncConnectionWizard.select_folders_to_sync(folders, new_sync_connection_wizard=True)
 
 
 @When('the user sorts the folder list by "{header_text}"')
@@ -181,9 +177,7 @@ def step(context):
     SyncConnectionWizard.set_sync_path()
 
 
-@When(
-    'the user sets the temp folder "{folder_name}" as local sync path in sync connection wizard'
-)
+@When('the user sets the temp folder "{folder_name}" as local sync path in sync connection wizard')
 def step(context, folder_name):
     sync_path = get_temp_resource_path(folder_name)
     SyncConnectionWizard.set_sync_path(sync_path)
@@ -252,9 +246,7 @@ def step(context):
 def step(context, user, sync_folder):
     Toolbar.open_account(user)
     has_sync_connection = SyncConnection.has_sync_connection(sync_folder)
-    with ensure(
-        'There should not be "{0}" folder sync connection, but found.', sync_folder
-    ):
+    with ensure('There should not be "{0}" folder sync connection, but found.', sync_folder):
         has_sync_connection.should.be.false
 
 
@@ -331,14 +323,10 @@ def step(context, wait_for):
     time.sleep(float(wait_for))
 
 
-@When(
-    'the user unselects the following folders to sync in "Choose what to sync" window:'
-)
+@When('the user unselects the following folders to sync in "Choose what to sync" window:')
 def step(context):
     SyncConnection.choose_what_to_sync()
     folders = []
     for row in context.table:
         folders.append(row[0])
-    SyncConnectionWizard.unselect_folders_to_sync(
-        folders, new_sync_connection_wizard=False
-    )
+    SyncConnectionWizard.unselect_folders_to_sync(folders, new_sync_connection_wizard=False)


### PR DESCRIPTION
Part of https://github.com/opencloud-eu/desktop/issues/553
* Configure Ruff with a `line-length` of **100**.
* Enable the following Ruff rule sets:
  * **`DTZ`** – Detect uses of naive `datetime` objects and encourage explicit timezone handling.
  * **`RET`** – Detect unnecessary or missing `return` statements and simplify return-related control flow.
* Re-enable **`E501`** by removing it from the global ignore list.
* Keep **`E501`** ignored only for `steps/*.py`, where long Behave step definitions are more readable and difficult to split.