### PR TITLE
Implement optional icon coloring with text color

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -78,6 +78,11 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     });
 
     connect(_ui->about_pushButton, &QPushButton::clicked, ocApp(), &Application::showAbout);
+
+    connect(_ui->textIconColorCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+        ConfigFile().setTextIconColor(checked);
+        QMessageBox::warning(this, tr("Warning"), tr("Changing this setting requires a restart of this application to take effect."), QMessageBox::Ok);
+    });
 }
 
 GeneralSettings::~GeneralSettings()
@@ -134,6 +139,7 @@ void GeneralSettings::slotIgnoreFilesEditor()
 
 void GeneralSettings::reloadConfig()
 {
+    _ui->textIconColorCheckBox->setChecked(ConfigFile().textIconColor());
     _ui->syncHiddenFilesCheckBox->setChecked(!FolderMan::instance()->ignoreHiddenFiles());
     _ui->moveToTrashCheckBox->setChecked(ConfigFile().moveToTrash());
     if (Utility::isWindows() && Utility::isInstalledByStore()) {

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -35,7 +35,7 @@
           <string>General Settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="1" column="0">
+          <item row="2" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_6">
             <item>
              <widget class="QLabel" name="languageLabel">
@@ -78,6 +78,13 @@
            <widget class="QCheckBox" name="autostartCheckBox">
             <property name="text">
              <string>Start on Login</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="textIconColorCheckBox">
+            <property name="text">
+             <string>Use text color for icon color</string>
             </property>
            </widget>
           </item>

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -471,6 +471,10 @@ int main(int argc, char **argv)
             return -1;
         }
 
+        // Early enough so all GUI elements pick it up
+        ConfigFile configFile;
+        qApp->setProperty("textIconColor", configFile.textIconColor());
+
         // Setup the folders. This includes a downgrade-detection, in which case the return value
         // is empty. Note that the value 0 (zero) is a valid return value (non-empty), in which case
         // the dialog is not shown.

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -97,6 +97,10 @@ QString excludeFileNameC()
 {
     return QStringLiteral("sync-exclude.lst");
 }
+const QString textIconColorC()
+{
+    return QStringLiteral("textIconColor");
+}
 
 } // anonymous namespace
 
@@ -516,5 +520,17 @@ void ConfigFile::setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles)
         qCInfo(lcConfigFile) << u"Adding user defined ignore list to csync:" << userList;
         excludedFiles.addExcludeFilePath(userList);
     }
+}
+
+bool ConfigFile::textIconColor() const
+{
+    auto settings = makeQSettings();
+    return settings.value(textIconColorC(), false).toBool();
+}
+
+void ConfigFile::setTextIconColor(bool enabled)
+{
+    auto settings = makeQSettings();
+    settings.setValue(textIconColorC(), enabled);
 }
 }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -149,6 +149,9 @@ public:
     /// Add the system and user exclude file path to the ExcludedFiles instance.
     static void setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles);
 
+    bool textIconColor() const;
+    void setTextIconColor(bool enabled);
+
 private:
     QVariant getValue(const QString &param, const QVariant &defaultValue = QVariant()) const;
     void setValue(const QString &key, const QVariant &value);

--- a/src/resources/resources.cpp
+++ b/src/resources/resources.cpp
@@ -23,6 +23,7 @@
 
 #include <QDebug>
 #include <QFileInfo>
+#include <QGuiApplication>
 #include <QImageReader>
 #include <QJsonDocument>
 #include <QLoggingCategory>
@@ -115,6 +116,10 @@ QIcon OCC::Resources::loadIcon(const QString &flavor, const QString &name, IconT
 
 QColor Resources::tint()
 {
+    if (qApp->property("textIconColor").toBool()) {
+        return QGuiApplication::palette().color(QPalette::Text);
+    }
+
     static QColor lilac{"#E2BAFF"};
     static QColor petrol{"#20434F"};
     return isUsingDarkTheme() ? lilac : petrol;


### PR DESCRIPTION
I have written the https://github.com/opencloud-eu/desktop/issues/809 issue originally.
This is a much simpler solution to my issue, which is the icon coloring.
It does not depend on system icons, so there is no possibility of one of them missing.
The restart mechanic is there as some parts of the GUI, mainly the top bar, do not refresh later. It was simpler this way, but if it should be avoided at all costs, I can look into adding a signal and refreshing when emitted.