### PR TITLE
refactor(gui-test): reduce Ruff ignores by fixing violations

### DIFF
--- a/test/gui/environment.py
+++ b/test/gui/environment.py
@@ -18,7 +18,7 @@ from helpers.ReportHelper import (
     cleanup_current_app_log,
     save_crash_log,
 )
-from step_types.types import *  # register all step types
+from step_types.types import *  # noqa: F403 # register all step types
 
 
 def before_feature(context, feature):

--- a/test/gui/helpers/FilesHelper.py
+++ b/test/gui/helpers/FilesHelper.py
@@ -43,7 +43,7 @@ def can_read(resource):
     try:
         with open(resource, encoding="utf-8"):
             read = True
-    except:
+    except Exception:
         pass
     return read and os.access(resource, os.R_OK)
 
@@ -53,7 +53,7 @@ def can_write(resource):
     try:
         with open(resource, "w", encoding="utf-8"):
             write = True
-    except:
+    except Exception:
         pass
     return write and os.access(resource, os.W_OK)
 

--- a/test/gui/helpers/SyncHelper.py
+++ b/test/gui/helpers/SyncHelper.py
@@ -174,7 +174,7 @@ def close_socket_connection():
         if is_windows():
             SOCKET_CONNECT.close_conn()
         elif is_linux():
-            SOCKET_CONNECT._sock.close()  # pylint: disable=protected-access
+            SOCKET_CONNECT._sock.close()
 
 
 def get_initial_sync_patterns():

--- a/test/gui/helpers/VFSFileHelper.py
+++ b/test/gui/helpers/VFSFileHelper.py
@@ -19,7 +19,7 @@ class FILETIME(ctypes.Structure):
     ]
 
 
-class WIN32_FILE_ATTRIBUTE_DATA(ctypes.Structure):
+class WIN32_FILE_ATTRIBUTE_DATA(ctypes.Structure):  # noqa: N801
     _fields_ = [
         ("dwFileAttributes", wintypes.DWORD),
         ("ftCreationTime", FILETIME),

--- a/test/gui/helpers/WinPipeHelper.py
+++ b/test/gui/helpers/WinPipeHelper.py
@@ -32,7 +32,7 @@ class WinPipeConnect:
     def __init__(self):
         self.connected = False
         self._pipe = None
-        self._remainder = ''.encode('utf-8')
+        self._remainder = b''
         self._overlapped = pywintypes.OVERLAPPED()
         self._overlapped.hEvent = win32event.CreateEvent(None, 1, 0, None)
         self.connect_to_pipe_server()
@@ -82,7 +82,7 @@ class WinPipeConnect:
     def read_socket_data_with_timeout(self, timeout):
         messages = b''
         start_time = time.time()
-        while True:  # pylint: disable=too-many-nested-blocks
+        while True:
             if (time.time() - start_time) >= timeout:
                 self._remainder += messages
                 break
@@ -100,7 +100,7 @@ class WinPipeConnect:
                                 start = m.split(b':', 1)[0]
                                 if start.decode('utf-8') in CLIENT_MESSAGES:
                                     messages += m + b'\n'
-                            except:
+                            except Exception:
                                 pass
 
             else:

--- a/test/gui/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/pageObjects/AccountConnectionWizard.py
@@ -1,8 +1,9 @@
 import os
-from time import time
+import time
 from types import SimpleNamespace
 from appium.webdriver.common.appiumby import AppiumBy as By
 from selenium.common.exceptions import WebDriverException
+
 
 from helpers.WebUIHelper import authorize_via_webui
 from helpers.ConfigHelper import get_config
@@ -245,7 +246,7 @@ class AccountConnectionWizard:
                 AccountConnectionWizard.CHOOSE_FOLDER_BUTTON.selector,
             )
             can_change = True
-        except:
+        except Exception:
             pass
         return can_change
 

--- a/test/gui/pageObjects/Activity.py
+++ b/test/gui/pageObjects/Activity.py
@@ -134,7 +134,7 @@ class Activity:
                     f'Activity for "{resource}" does not have "{account}" account label'
                 )
             return True
-        except:
+        except Exception:
             return False
 
     @staticmethod

--- a/test/gui/pyproject.toml
+++ b/test/gui/pyproject.toml
@@ -52,14 +52,9 @@ select = [
 
 # See the available rules: https://docs.astral.sh/ruff/rules/
 ignore = [
-    "F403",     # Wildcard import (`from x import *`)
-    "E722",     # Bare `except`
     "SIM105",   # Use `contextlib.suppress`
     "SIM110",   # Use `any()` instead of loop
-    "UP012",    # Remove unnecessary UTF-8 encoding
-    "SIM113",   # Use enumerate() instead of a manual loop counter
     "N812",     # Lowercase imported as non-lowercase
-    "N801",     # Allow non-CapWords class names
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/test/gui/steps/file_context.py
+++ b/test/gui/steps/file_context.py
@@ -80,7 +80,7 @@ def try_to_write_file(resource, content):
     listen_sync_status_for_item(get_resource_path(resource), 'FILE')
     try:
         write_file(resource, content)
-    except:
+    except Exception:
         pass
 
 

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -156,13 +156,11 @@ def step(context):
 @Then('the folders should be in the following order:')
 def step(context):
     row_index = 0
-    for row in context.table:
+    for row_index, row in enumerate(context.table):
         expected_folder = row[0]
         actual_folder = SyncConnectionWizard.get_item_name_from_row(row_index)
         with ensure(f"Expected '{expected_folder}', got '{actual_folder}'"):
             actual_folder.should.be.equal(expected_folder)
-
-        row_index += 1
 
 
 @When('the user selects "{space_name}" space in sync connection wizard')


### PR DESCRIPTION
Part of https://github.com/opencloud-eu/desktop/issues/553
### Summary

Reduced the number of ignored Ruff rules by fixing the corresponding lint violations in the codebase.

### Removed from ignore list

* `F403` – Wildcard import (`from x import *`)
* `E722` – Bare `except`
* `UP012` – Remove unnecessary UTF-8 encoding
* `SIM113` – Use `enumerate()` instead of a manual loop counter
* `N801` – Non-CapWords class names

