### PR TITLE
add msix signing

### DIFF
--- a/.craft.ini
+++ b/.craft.ini
@@ -41,6 +41,7 @@ Packager/CreateCache = ${Variables:CreateCache}
 Packager/PackageDebugSymbols = ${Env:CRAFT_PACKAGE_SYMBOLS}
 Packager/DownloadDebugSymbolsCache = ${Env:CRAFT_PACKAGE_SYMBOLS}
 Packager/AppxPublisherId = CN=44DA8A24-8237-46B0-B4A2-D297A6A22705
+Packager/AppxPackageType = msix
 Compile/BuildType = RelWithDebInfo
 ContinuousIntegration/Enabled = ${Variables:CiBuild}
 ContinuousIntegration/UpdateRepository = True
@@ -48,6 +49,9 @@ CodeSigning/Enabled = ${Env:SIGN_PACKAGE}
 CodeSigning/Protected = True
 CodeSigning/Certificate = ${Env:CRAFT_CODESIGN_CERTIFICATE}
 CodeSigning/CommonName =
+CodeSigning/Organization =
+CodeSigning/State =
+CodeSigning/Country =
 CodeSigning/MacDeveloperId = OpenCloud GmbH (8P6LQ2M542)
 CodeSigning/MacAppleID = devops@opencloud.eu
 CodeSigning/MacKeychainPath = sign-${Env:DRONE_BUILD_NUMBER}.keychain

--- a/.github/workflows/.signpath.ps1
+++ b/.github/workflows/.signpath.ps1
@@ -1,0 +1,5 @@
+# For Craft to create sideload packages it needs CodeSigning to be enabled.
+# We are setting a custom command (this script) to skip singing.
+# We later sign using the SignPath GitHub Action.
+
+Write-Output "use github action for deep signing, return 0 to force unsigned sideload artifact"

--- a/.github/workflows/craft_override.ini
+++ b/.github/workflows/craft_override.ini
@@ -5,10 +5,14 @@ Packager/CreateCache = False
 Paths/CCACHE_DIR = ${Env:HOME}/ccache
 Compile/UseCCache = True
 
+CodeSigning/Enabled = False
+
 [windows-cl-msvc2022-x86_64]
 # used on Windows to work around long path issues. Should be the same as HOME
 ShortPath/JunctionDir = ${Env:SYSTEMDRIVE}/_
-
+CodeSigning/Enabled = True
+CodeSigning/CommonName = Test certificate for 'OpenCloud Desktop Client [OSS]'
+CodeSigning/WindowsCustomSignCommand = pwsh -File "${Env:GITHUB_WORKSPACE}/.github/workflows/.signpath.ps1" -F "%F"
 
 [linux-gcc-x86_64]
 Environment/SourceCommand = export PKG_CONFIG_PATH=(/usr/bin/pkg-config --variable pc_path pkg-config) && source /opt/rh/gcc-toolset-14/enable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ on:
           - stable
           - beta
 
-
 concurrency: 
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -35,6 +34,7 @@ jobs:
     permissions:
       # actions/upload-artifact doesn't need contents: write
       contents: read
+      actions: read
     strategy:
         fail-fast: true
         matrix:
@@ -186,14 +186,9 @@ jobs:
         & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --run python3 -m clang_html "$([System.IO.Path]::GetTempPath())/clang-tidy.log" -o "${env:GITHUB_WORKSPACE}/binaries/clang-tidy.html"
 
     - name: Package
-      if: matrix.target  != 'macos-clang-arm64'
+      if: matrix.target == 'linux-gcc-x86_64'
       run: |
         & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --package opencloud/opencloud-desktop
-
-    - name: Package Appx
-      if: ${{ matrix.os  == 'windows-latest' && github.event_name != 'pull_request' }}
-      run: |
-        & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --package --options "[Packager]PackageType=AppxPackager" --options "[Packager]Destination=${{ github.workspace }}/appx/" opencloud/opencloud-desktop
 
     - name: Prepare artifacts
       run: |
@@ -207,15 +202,54 @@ jobs:
           }
         }
 
-    - name: Upload artifacts
+    - name: Package msix
+      if: ${{ startsWith(matrix.os, 'windows-') && github.event_name != 'pull_request' }}
+      run: |
+        & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --package --options "[Packager]PackageType=AppxPackager" --options "[Packager]Destination=${{ github.workspace }}/msix/" opencloud/opencloud-desktop
+        Move-Item -Path "${{ github.workspace }}/msix/*.msix" -Destination "${{ github.workspace }}/msix/OpenCloud_Desktop-${{ github.run_number }}.msix" -Force
+
+    - name: Upload binary artifacts
       uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.target }}-${{ github.run_number }}
         path: ${{ github.workspace }}/binaries/*
 
-    - name: Upload appx
-      if: ${{ matrix.os  == 'windows-latest' && github.event_name != 'pull_request' }}
+    - name: Upload store msix
+      if: ${{ startsWith(matrix.os, 'windows-') && github.event_name != 'pull_request' }}
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ matrix.target }}-appx-${{ github.run_number }}
-        path: ${{ github.workspace }}/appx/*
+        name: ${{ matrix.target }}-store-msix-${{ github.run_number }}
+        path: ${{ github.workspace }}/msix/*.msixupload
+        archive: false
+
+    - name: Upload unsigned msix
+      id: upload-unsigned-artifact
+      if: ${{ startsWith(matrix.os, 'windows-') && github.event_name != 'pull_request' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.target }}-msix-unsigned-temp-${{ github.run_number }}
+        path: ${{ github.workspace }}/msix/*.msix
+
+    - name: submit msix for signing
+      uses: signpath/github-action-submit-signing-request@v2
+      if: ${{ startsWith(matrix.os, 'windows-') && github.event_name != 'pull_request' }}
+      with:
+        api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+        organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
+        project-slug: 'desktop'
+        signing-policy-slug: 'test-signing'
+        artifact-configuration-slug: 'deep_sign_msix_zip'
+        output-artifact-directory: '${{ github.workspace }}/msix/'
+        skip-decompress: false
+        github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+        wait-for-completion: true
+
+    - name: Upload signed msix
+      id: upload-signed-artifact
+      if: ${{ startsWith(matrix.os, 'windows-') && github.event_name != 'pull_request' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.target }}-msix-${{ github.run_number }}
+        path: ${{ github.workspace }}/msix/*.msix
+        archive: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,6 @@ jobs:
           ~/ccache
         key: ${{ runner.os }}-${{ matrix.target }}
 
-
     - name: Clone CraftMaster
       run: |
         git clone --depth=1 https://invent.kde.org/kde/craftmaster.git "${home}/craft/CraftMaster/CraftMaster"
@@ -205,7 +204,7 @@ jobs:
     - name: Package msix
       if: ${{ startsWith(matrix.os, 'windows-') && github.event_name != 'pull_request' }}
       run: |
-        & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --package --options "[Packager]PackageType=AppxPackager" --options "[Packager]Destination=${{ github.workspace }}/msix/" opencloud/opencloud-desktop
+        & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --package --options "[Packager]PackageDebugSymbols=False" --options "[Packager]PackageType=AppxPackager" --options "[Packager]Destination=${{ github.workspace }}/msix/" opencloud/opencloud-desktop
         Move-Item -Path "${{ github.workspace }}/msix/*.msix" -Destination "${{ github.workspace }}/msix/OpenCloud_Desktop-${{ github.run_number }}.msix" -Force
 
     - name: Upload binary artifacts


### PR DESCRIPTION
create msix instead of appx,
force sideload app creation with craft,
add github-action to sign and then upload the stand-alone msix-Package

The used certificate is currently only for testing, and will be replaced as soon as a valid certificate is available

The certificate can be extracted from the msix and imported into the system store using:
`Import-Certificate -FilePath .\test_certificate_2026.pem -CertStoreLocation Cert:\LocalMachine\Root`