### PR TITLE
chore: add appstream metainfo

### DIFF
--- a/eu.opencloud.OpenCloudDesktop.metainfo.xml
+++ b/eu.opencloud.OpenCloudDesktop.metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>eu.opencloud.desktop.OpenCloud</id>
+  
+  <name>OpenCloud Desktop</name>
+  <summary>Desktop client for OpenCloud file synchronization</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  
+  <description>
+    <p>
+      The OpenCloud Desktop Client synchronizes files between your computer and OpenCloud. It provides offline access, automatic synchronization, and a consistent way to work with files locally.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">opencloud.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://docs.opencloud.eu/assets/images/settings-overview-561af2cba465818c58a388c454830451.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://docs.opencloud.eu/assets/images/set-up-enter-url-57bd85c39ceb0145112bf9d34d72d508.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -217,4 +217,5 @@ if(UNIX AND NOT APPLE)
     configure_file(${CMAKE_SOURCE_DIR}/opencloud.desktop.in
                    ${CMAKE_CURRENT_BINARY_DIR}/${APPLICATION_EXECUTABLE}.desktop)
     install(FILES  ${CMAKE_CURRENT_BINARY_DIR}/${APPLICATION_EXECUTABLE}.desktop DESTINATION ${KDE_INSTALL_DATADIR}/applications )
+    install(FILES ${CMAKE_SOURCE_DIR}/eu.opencloud.OpenCloudDesktop.metainfo.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
 endif()


### PR DESCRIPTION
This PR adds FreeDesktop [AppStream](https://www.freedesktop.org/software/appstream/docs/) metadata to this project. It was created using the [MetaInfo Creator](https://www.freedesktop.org/software/appstream/metainfocreator/#/guiapp).

This metainfo is required for submission in some other appstores/remotes such as Flathub. In https://github.com/opencloud-eu/desktop/issues/517#issuecomment-3265419148 it has been said that no official flatpak will be available, but community effort will be supported.

I have tracked my [own flatpak definition](https://github.com/p-fruck/eu.opencloud.desktop/) for over a year now and would really like to see some flatpak remote allowing me to "just install" and autoupdate the OpenCloud Desktop. Hence, I submitted my manifest to flathub in  https://github.com/flathub/flathub/pull/9623 and integrated their feedback.

I am open to any changes/suggestions, I just want some appstream metainfo to be available upstream :)