### PR TITLE
test(gui-test): ensure sync does not create duplicate Unicode folders

### DIFF
--- a/test/gui/features/sync-edge-cases/syncResources.feature
+++ b/test/gui/features/sync-edge-cases/syncResources.feature
@@ -219,3 +219,22 @@ Feature: Syncing files
         And as "Brian" folder "Shares/simple-folder/sub-folder" should exist in the server
         And as "Brian" file "Shares/simple-folder/simple.pdf" should exist in the server
         And as "Brian" the file "Shares/simple-folder/uploaded-lorem.txt" should have the content "overwrite openCloud test text file" in the server
+
+
+    Scenario:  Sync same unicode folder from server and client at the same time
+        Given user "Alice" has set up a client with default settings
+        And the user has paused the file sync
+        And user "Alice" has created folder "Öü" in the server
+        And user "Alice" has uploaded file with content "openCloud test" to "Öü/testFile.txt" in the server
+        When user "Alice" creates a folder "Öü" inside the sync folder
+        When user "Alice" creates a file "Öü/newfile.txt" with the following content inside the sync folder
+            """
+            test content
+            """
+        And the user waits for "1" seconds
+        And the user resumes the file sync on the client
+        And the user waits for the files to sync
+        Then the file "Öü/newfile.txt" should exist on the file system
+        And as user "Alice" folder "/" should contain "1" items in the server
+        And as "Alice" file "Öü/testFile.txt" should exist in the server
+        And as "Alice" file "Öü/newfile.txt" should exist in the server

--- a/test/gui/helpers/api/webdav_helper.py
+++ b/test/gui/helpers/api/webdav_helper.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import quote
 import xml.etree.ElementTree as ET
 import json
@@ -54,14 +55,18 @@ def get_folder_items(user, resource):
 
 def get_folder_items_count(user, folder_name):
     folder_name = folder_name.strip('/')
+    if folder_name != '':
+        folder_name += '/'
     root_element = get_folder_items(user, folder_name)
     total_items = 0
+
     for response_element in root_element:
         for href_element in response_element:
-            # The first item is folder itself so excluding it
-            if href_element.tag == '{DAV:}href' and not href_element.text.endswith(
-                f'{user}/{folder_name}/'
-            ):
+            if not href_element.text:
+                continue
+            is_folder_item = re.search(f'/{user}/{folder_name}.+', href_element.text)
+            shares_folder = href_element.text.endswith(f'/{user}/Shares/')
+            if href_element.tag == '{DAV:}href' and is_folder_item and not shares_folder:
                 total_items += 1
     return str(total_items)
 

--- a/test/gui/steps/server_context.py
+++ b/test/gui/steps/server_context.py
@@ -51,11 +51,11 @@ def step(context, user_name, file_name, content):
 
 
 @Then(
-    r'as user "{user_name}" folder "{folder_name}" should contain "{items_number}" items in the server'
+    'as user "{user_name}" folder "{folder_name}" should contain "{items_number}" items in the server'
 )
 def step(context, user_name, folder_name, items_number):
     total_items = webdav.get_folder_items_count(user_name, folder_name)
-    with ensure(f'Folder should contain {items_number} items'):
+    with ensure(f'Folder should contain {items_number} items, but found {total_items}'):
         total_items.should.equal(items_number)
 
 

--- a/test/gui/steps/sync_context.py
+++ b/test/gui/steps/sync_context.py
@@ -316,6 +316,7 @@ def step(context):
         expected_error_message.should.equal(actual_error_message)
 
 
+@When('the user waits for "{wait_for}" seconds')
 @Given('the user has waited for "{wait_for}" seconds')
 def step(context, wait_for):
     time.sleep(float(wait_for))


### PR DESCRIPTION
Fixes: https://github.com/opencloud-eu/desktop/issues/609

## Summary

Add an integration test for Unicode folder normalization during synchronization.

## Changes

* Added a Gherkin scenario to verify that syncing the same Unicode folder from the server and client does not create duplicates.
* Updated the `get_folder_items_count()` helper function to correctly handle the root folder and exclude the default `Shares` folder.
