### PR TITLE
chore: fix appstream metainfo appid

### DIFF
--- a/eu.opencloud.OpenCloudDesktop.metainfo.xml
+++ b/eu.opencloud.OpenCloudDesktop.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>eu.opencloud.desktop.OpenCloud</id>
+  <id>eu.opencloud.OpenCloudDesktop</id>
   
   <name>OpenCloud Desktop</name>
   <summary>Desktop client for OpenCloud file synchronization</summary>


### PR DESCRIPTION
@TheOneRing sorry I renamed the metainfo file but forgot to change the appid accordingly. The appid must match the filename  according to spec