### PR TITLE
ci: remove always pull image config

### DIFF
--- a/.woodpecker/cache-python.yaml
+++ b/.woodpecker/cache-python.yaml
@@ -58,7 +58,6 @@ steps:
 
   - name: install-python-modules
     image: *build_image
-    pull: true # remove this once the nightlies run with the new build image
     commands:
       - . ./.woodpecker.env
       - if $PYTHON_CACHE_FOUND; then exit 0; fi
@@ -68,7 +67,6 @@ steps:
 
   - name: install-browsers
     image: *build_image
-    pull: true # remove this once the nightlies run with the new build image
     environment:
       PLAYWRIGHT_BROWSERS_PATH: /woodpecker/desktop/test/gui/.playwright
     commands:

--- a/.woodpecker/ui-tests.yaml
+++ b/.woodpecker/ui-tests.yaml
@@ -69,7 +69,6 @@ steps:
 
   - name: install-python-modules
     image: *build_image
-    pull: true # remove this once the nightlies run with the new build image
     environment:
       PLAYWRIGHT_BROWSERS_PATH: /woodpecker/desktop/test/gui/.playwright
     commands:
@@ -113,7 +112,6 @@ steps:
 
   - name: gui-tests
     image: *build_image
-    pull: true # remove this once the nightlies run with the new build image
     environment:
       # system cache environment variables
       PYTHONUSERBASE: /woodpecker/desktop/test/gui/.venv


### PR DESCRIPTION
Remove the following always pull image ci config.
```yaml
pull: true
```