### PR TITLE
move Signing vars into gh env

### DIFF
--- a/.github/workflows/craft_override.ini
+++ b/.github/workflows/craft_override.ini
@@ -5,23 +5,19 @@ Packager/CreateCache = False
 Paths/CCACHE_DIR = ${Env:HOME}/ccache
 Compile/UseCCache = True
 
-CodeSigning/Enabled = False
 CodeSigning/MacKeychainPath = ${Env:SIGNING_KEY_FILE_PATH}
 
 
 [windows-cl-msvc2022-x86_64]
 # used on Windows to work around long path issues. Should be the same as HOME
 ShortPath/JunctionDir = ${Env:SYSTEMDRIVE}/_
-CodeSigning/Enabled = True
 CodeSigning/CommonName = Test certificate for 'OpenCloud Desktop Client [OSS]'
 CodeSigning/WindowsCustomSignCommand = pwsh -File "${Env:GITHUB_WORKSPACE}/.github/workflows/.signpath.ps1" -F "%F"
 
 [macos-clang-x86_64]
-CodeSigning/Enabled = True
 Packager/PackageType = MacPkgPackager
 
 [macos-clang-arm64]
-CodeSigning/Enabled = True
 Packager/PackageType = MacPkgPackager
 
 [linux-gcc-x86_64]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,12 @@ jobs:
 
     environment:
       # set the environment name to main for pushes against main or stable-branches else empty string
+      # the environment contains the env var SIGN_PACKAGE=true
+      # and the required secrets for signing the packages
       name: ${{
         case(
-          github.event_name != 'pull_request' && github.ref == 'refs/heads/main', 'main',
-          github.event_name != 'pull_request' && startswith(github.ref, 'refs/heads/stable-'), 'main',
+          (github.event_name == 'workflow_dispatch' || startswith(github.ref, 'refs/tags/')) && github.ref == 'refs/heads/main', 'main',
+          (github.event_name == 'workflow_dispatch' || startswith(github.ref, 'refs/tags/')) && startswith(github.ref, 'refs/heads/stable-'), 'main',
           ''
           )
         }}


### PR DESCRIPTION
remove the SIGN_PACKAGE environment from the craft override.ini
so it defaults to false, and move it into the github environment
for builds to be signed only on dispatch events and, in the future,
tag events.

Caution: this pr is dependent on [this pr](https://github.com/opencloud-eu/desktop/pull/1024)