### PR TITLE
Fix issue with unicode paths in qml

### DIFF
--- a/src/gui/qml/FolderDelegate.qml
+++ b/src/gui/qml/FolderDelegate.qml
@@ -318,7 +318,7 @@ Pane {
 
                             MenuItem {
                                 text: CommonStrings.showInFileBrowser()
-                                onTriggered: Qt.openUrlExternally("file:///" + folderDelegate.folder.path)
+                                onTriggered: OCUtils.showInFileManager(folderDelegate.folder.path)
                             }
 
                             MenuItem {

--- a/src/gui/qmlutils.cpp
+++ b/src/gui/qmlutils.cpp
@@ -15,6 +15,7 @@
 #include "gui/qmlutils.h"
 
 #include "gui/fonticonmessagebox.h"
+#include "gui/openfilemanager.h"
 #include "resources/resources.h"
 
 #include <QMessageBox>
@@ -105,6 +106,11 @@ QUrl OCC::QmlUtils::OCUtils::resourcePath2(const QString &provider, const QStrin
 QUrl OCC::QmlUtils::OCUtils::avatarPath(const QString &accountID, bool enabled, int size)
 {
     return resourcePath2(u"avatar"_s, {}, accountID, enabled, size, {});
+}
+
+void OCC::QmlUtils::OCUtils::showInFileManager(const QString &path)
+{
+    OCC::showInFileManager(path);
 }
 
 int OCC::QmlUtils::OCUtils::compareQVersion(int major, int minor, int patch) const

--- a/src/gui/qmlutils.h
+++ b/src/gui/qmlutils.h
@@ -81,5 +81,7 @@ public:
         const QString &provider, const QString &theme, const QString &icon, bool enabled = true, int size = 0, const QColor &color = {});
 
     Q_INVOKABLE QUrl avatarPath(const QString &accountID, bool enabled = true, int size = 0);
+
+    Q_INVOKABLE void showInFileManager(const QString &path);
 };
 }


### PR DESCRIPTION
Instead of constructing a file path in qml we now expose and use showInFileManager in qml

Fixes: #938