### PR TITLE
Retry PROPFIND/GET/HEAD on a status-0 transport failure instead of aborting sync

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -129,6 +129,16 @@ bool AbstractNetworkJob::needsRetry() const
             }
             [[fallthrough]];
         default:
+            // A reply with no HTTP status at all (HttpStatusCodeAttribute unset, so
+            // httpStatusCode() reads back as 0) never reached the application layer - the
+            // connection was torn down before any response line was parsed, e.g. a
+            // client-side HTTP/2 GOAWAY racing an in-flight stream (see #1026). The server
+            // never confirmed it saw the request, so blindly retrying is only safe for
+            // read-only, idempotent verbs.
+            if (httpStatusCode() == 0
+                && (_verb == QByteArrayLiteral("GET") || _verb == QByteArrayLiteral("HEAD") || _verb == QByteArrayLiteral("PROPFIND"))) {
+                return true;
+            }
             break;
         }
     }

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -178,6 +178,38 @@ private Q_SLOTS:
         QCOMPARE(errorSpy[0][0].toString(), formatAbortError(syncRootError.isEmpty() ? QString(fatalErrorPrefix + expectedErrorString) : syncRootError));
     }
 
+    // Regression test for #1026: a PROPFIND reply with HTTP status 0 and no error text
+    // (e.g. a client-side HTTP/2 GOAWAY racing an in-flight stream) is a transport
+    // failure, not a server error, and must be retried at the request level instead of
+    // aborting the whole sync run.
+    void testRemoteDiscoveryRetriesTransportFailure()
+    {
+        QFETCH_GLOBAL(Vfs::Mode, vfsMode);
+        QFETCH_GLOBAL(bool, filesAreDehydrated);
+
+        FakeFolder fakeFolder(FileInfo::A12_B12_C12_S12(), vfsMode, filesAreDehydrated);
+        fakeFolder.remoteModifier().insert(QStringLiteral("B/z2"));
+
+        QString errorFolder = Utility::concatUrlPath(OCC::TestUtils::dummyDavUrl(), QStringLiteral("B")).path();
+        bool firstAttempt = true;
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *) -> QNetworkReply * {
+            if (req.attribute(QNetworkRequest::CustomVerbAttribute).toByteArray() == "PROPFIND" && req.url().path().endsWith(errorFolder)) {
+                if (firstAttempt) {
+                    firstAttempt = false;
+                    // status 0, no error text: exactly what a client-side HTTP/2 GOAWAY produces
+                    return new FakeErrorReply(op, req, this, 0);
+                }
+            }
+            return nullptr;
+        });
+
+        QSignalSpy errorSpy(&fakeFolder.syncEngine(), &SyncEngine::syncError);
+        QVERIFY(fakeFolder.applyLocalModificationsAndSync());
+        QCOMPARE(errorSpy.size(), 0);
+        QVERIFY(!firstAttempt); // the transient reply was actually hit, not skipped
+        QCOMPARE(fakeFolder.currentRemoteState().children[QStringLiteral("B")], fakeFolder.currentLocalState().children[QStringLiteral("B")]);
+    }
+
     void testMissingData()
     {
         QFETCH_GLOBAL(Vfs::Mode, vfsMode);


### PR DESCRIPTION
## Summary

Fixes #1026. A PROPFIND reply with HTTP status `0` and no error text never reached the application layer - the connection was torn down before any response line was parsed (e.g. a client-side HTTP/2 GOAWAY racing an in-flight stream, as documented in #1026 with full client/server log evidence).

`discovery.cpp`'s `startAsyncServerQuery` handler currently classifies **any** such reply as a fatal, whole-run-aborting server error: it checks `code == 404` for the root path and `code >= 403` for a subdirectory (to gracefully ignore just that directory), but a status of `0` matches neither, so it always falls through to the final `fatalError` branch meant for "the root job... or network errors."

## Fix

`AbstractNetworkJob` already has a retry mechanism (`JobQueue`/`needsRetry()`) that recovers from specific transient conditions - unsupported redirects, expired auth, and (for HTTP/2 specifically) `ContentReSendError`. This PR extends `needsRetry()` with one more case: when `httpStatusCode() == 0` (no HTTP status was ever received) **and** the request verb is read-only/idempotent (`GET`, `HEAD`, `PROPFIND`). Since the server never confirmed it saw the request, retrying is safe for these verbs without the double-processing risk a write (`PUT`/`DELETE`/`MKCOL`/`MOVE`) would carry, so the verb check is intentionally conservative.

This means a single dropped PROPFIND during discovery gets retried (up to the existing `MaxRetryCount = 5`) exactly like the other already-handled recoverable cases, instead of aborting the entire sync run.

## Testing

Added `testRemoteDiscoveryRetriesTransportFailure` in `test/testremotediscovery.cpp`, modeled on the existing `testRemoteDiscoveryError` fixture: the fake server returns a status-0 `FakeErrorReply` for the first PROPFIND on a subdirectory, then a normal reply on retry, and asserts the sync completes with no `syncError` and the directory fully matches between local and remote.

I wasn't able to build/run this locally (no Qt/CMake toolchain available in my environment) - relying on CI to validate compilation and the new test. Happy to iterate on feedback.

## Note on PR #1010

#1026 was closed as a duplicate referencing #1010 ("Disable HTTP/2 support again"), which works around the whole class of GOAWAY-related failures by disabling HTTP/2 client-side. This PR is a narrower, independent fix for the underlying error-handling gap (any transport failure with no HTTP status aborts the whole sync, not just HTTP/2-specific ones) and should be safe to land alongside or independently of that workaround.