### PR TITLE
Addresses #843 - clean up the Excluded tag on VFS status change

### DIFF
--- a/src/plugins/vfs/openvfs/vfs_openvfs.cpp
+++ b/src/plugins/vfs/openvfs/vfs_openvfs.cpp
@@ -580,6 +580,14 @@ void OpenVFS::fileStatusChanged(const QString &systemFileName, SyncFileStatus fi
         setPinState(rel.toString(), PinState::Excluded);
         return;
     }
+    if (fileStatus.tag() == SyncFileStatus::StatusUpToDate) {
+        const auto attribs = placeHolderAttributes(systemFileName);
+        if (attribs && attribs.pinState == convertPinState(PinState::Excluded)) {
+            const FileSystem::Path rel = FileSystem::Path(systemFileName)->lexically_relative(params().root());
+            setPinState(rel.toString(), PinState::Inherited);
+        }
+        return;
+    }
     qCDebug(lcOpenVFS) << systemFileName << fileStatus;
 }
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -700,6 +700,30 @@ private Q_SLOTS:
         QVERIFY(fakeFolder.currentRemoteState().find(QStringLiteral("B/.hidden")));
     }
 
+    void testRenameExcludedFile()
+    {
+        if (!VfsPluginManager::instance().isVfsPluginAvailable(Vfs::Mode::OpenVFS)) {
+            QSKIP("Pin states require the OpenVFS plugin");
+        }
+
+        FakeFolder fakeFolder(FileInfo::A12_B12_C12_S12(), Vfs::Mode::OpenVFS, false);
+        fakeFolder.syncEngine().setIgnoreHiddenFiles(true);
+
+        fakeFolder.localModifier().rename(QStringLiteral("A/a1"), QStringLiteral("A/.a1"));
+        QVERIFY(fakeFolder.applyLocalModificationsAndSync());
+        QVERIFY(!fakeFolder.currentRemoteState().find(QStringLiteral("A/a1")));
+        const auto excludedPin = fakeFolder.vfs()->pinState(QStringLiteral("A/.a1"));
+        QVERIFY(excludedPin);
+        QCOMPARE(*excludedPin, PinState::Excluded);
+
+        fakeFolder.localModifier().rename(QStringLiteral("A/.a1"), QStringLiteral("A/a1renamed"));
+        QVERIFY(fakeFolder.applyLocalModificationsAndSync());
+        QVERIFY(fakeFolder.currentRemoteState().find(QStringLiteral("A/a1renamed")));
+        const auto pin = fakeFolder.vfs()->pinState(QStringLiteral("A/a1renamed"));
+        QVERIFY(pin);
+        QVERIFY(*pin != PinState::Excluded);
+    }
+
 #ifndef Q_OS_WIN
     void testPropagatePermissions()
     {


### PR DESCRIPTION
Add a SyncFileStatus condition to clean up the Excluded tag + a simple test
Tested on my local Arch machine ( I'm unable to test this on other operating systems)