### PR TITLE
Add helper to print vfs plugin availability

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,24 @@ include(opencloud_add_test.cmake)
 add_subdirectory(manual/icon_viewer)
 add_subdirectory(testutils)
 
+
+# Helper application used by CI and local test runs to report which VFS plugins
+# are available at runtime. A plugin may build successfully on a system but
+# still fail to load there because of system-specific runtime dependencies.
+# This distinction is relevant when interpreting the unit-test results.
+add_executable(test_vfs_availability test_vfs_availability.cpp)
+target_link_libraries(test_vfs_availability OpenCloudGui)
+
+add_custom_command(
+        TARGET test_vfs_availability
+        COMMAND test_vfs_availability
+        COMMENT "listing plugin availability on this system"
+        VERBATIM
+        POST_BUILD
+)
+
+
+
 opencloud_add_test(JHash)
 opencloud_add_test(Jwt)
 

--- a/test/test_vfs_availability.cpp
+++ b/test/test_vfs_availability.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2026 Hannah von Reth <h.vonreth@opencloud.eu>
+
+#include "libsync/vfs/vfs.h"
+
+#include <QCoreApplication>
+#include <QTimer>
+
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+    QTimer::singleShot(0, &app, [] {
+        for (int i = 0; i <= static_cast<int>(OCC::Vfs::Mode::OpenVFS); ++i) {
+            const auto mode = static_cast<OCC::Vfs::Mode>(i);
+            auto instance = OCC::VfsPluginManager::instance().createVfsFromPlugin(mode);
+            std::cout << "Plugin: " << OCC::Utility::enumToString(mode).toStdString() << (instance ? " is available" : " is unavailable") << std::endl;
+        }
+        QCoreApplication::quit();
+    });
+    return QCoreApplication::exec();
+}


### PR DESCRIPTION
The cfapi plugin requires some runtime component that is only available in a full desktop installation (not a core server).
As the unit tests for cfapi are skipped if plugin loading fails and the unit tests only log if a test fails, the output of this helper will help us to understand whether the tests were actually run.