### PR TITLE
Update system info string format in theme.cpp

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -228,8 +228,8 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
             gitUrl = gitSHA1(format) + br;
         }
     }
-    QStringList sysInfo = {QStringLiteral("OS: %1-%2 (build arch: %3, CPU arch: %4)")
-                               .arg(QSysInfo::productType(), QSysInfo::kernelVersion(), QSysInfo::buildCpuArchitecture(), Utility::currentCpuArch())};
+    QStringList sysInfo = {QStringLiteral("OS: %1-%2 (kernel: %3, build arch: %4, CPU arch: %5)")
+                               .arg(QSysInfo::productType(), QSysInfo::productVersion(), QSysInfo::kernelVersion(), QSysInfo::buildCpuArchitecture(), Utility::currentCpuArch())};
     // may be called by both GUI and CLI, but we can display QPA only for the former
     if (auto guiApp = qobject_cast<QGuiApplication *>(qApp)) {
         sysInfo << QStringLiteral("QPA: %1").arg(guiApp->platformName());


### PR DESCRIPTION
The version info in the about screen showed:

OS: opensuse-leap-6.4.0-150600.23.103-default (build arch: x86_64, CPU arch: x86_64)

BAD: this is confusing, as opensuse-leap never had a version 6.4.0, (this S.U.S.E. version predates the introduction of leap)

I suggest to change the message to include the QSysInfo::productVersion with the os, and print the kernel version 6.4.0 in an extra entry.