### PR TITLE
test(gui): bump pypdf from 6.14 to 6.18

### DIFF
--- a/test/gui/pyproject.toml
+++ b/test/gui/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "psutil==7.2.*",
     "pyautogui==0.9.*",
     "pygobject==3.48.* ; sys_platform == 'linux'",
-    "pypdf==6.14.*",
+    "pypdf==6.18.*",
     "pyside6==6.11.*",
     "python-docx==1.2.*",
     "python-pptx==1.0.*",

--- a/test/gui/uv.lock
+++ b/test/gui/uv.lock
@@ -356,7 +356,7 @@ requires-dist = [
     { name = "psutil", specifier = "==7.2.*" },
     { name = "pyautogui", specifier = "==0.9.*" },
     { name = "pygobject", marker = "sys_platform == 'linux'", specifier = "==3.48.*" },
-    { name = "pypdf", specifier = "==6.14.*" },
+    { name = "pypdf", specifier = "==6.18.*" },
     { name = "pyside6", specifier = "==6.11.*" },
     { name = "python-docx", specifier = "==1.2.*" },
     { name = "python-pptx", specifier = "==1.0.*" },
@@ -892,11 +892,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c3/9fa0666f280552bd3833562d985b785fce1ddb3804937edd2fd6a3f2bdb3/pypdf-6.18.0.tar.gz", hash = "sha256:ae58b7d93c22c169ffb02c3b06321c45c4f223b4916536568adb57d789d95d01", size = 7024871, upload-time = "2026-09-07T16:48:16.444Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a5/d5922a078c9a612327681d4793404f82998f4d66213add6fdc0659245856/pypdf-6.18.0-py3-none-any.whl", hash = "sha256:05b762b77bcb9dcb4a7c91fcf5dded585b25bee7269ab3d3001d7c55fa1b324b", size = 393848, upload-time = "2026-09-07T16:48:14.254Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update pypdf.

Fixes security alerts: https://github.com/opencloud-eu/desktop/security/dependabot/119