### PR TITLE
Fallback to consent if prompt_values_supported is not exposed

### DIFF
--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -683,6 +683,8 @@ void OAuth::fetchWellKnown()
                             if (flag & defaultOauthPromtValue())
                                 _supportedPromtValues |= flag;
                         }
+                    } else {
+                        _supportedPromtValues = PromptValuesSupported::consent;
                     }
 
                     qCDebug(lcOauth) << u"parsing .well-known reply successful, auth endpoint" << _authEndpoint << u"and token endpoint" << _tokenEndpoint


### PR DESCRIPTION
Coincidentally, this fixes support for entraid.

While support all prompt values, they don't support combinations. https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#fetch-the-openid-configuration-document

prompt_values_supported is not exposed in:
https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration